### PR TITLE
Add .gitattributes file to fix language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+src/disasm-lib/* linguist-vendored
+src/mhook-lib/* linguist-vendored


### PR DESCRIPTION
Content:
- `.gitattributes` file to fix repo linguist stats in line with [Linguist Docs](https://github.com/github/linguist/blob/master/docs/overrides.md)
- The file ignores the folders relative to `mhook` and `disasm` libs