### PR TITLE
Fix PS v7 compatibility

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -23,6 +23,11 @@ Write-Host 'Stopping Spotify...'`n
 Stop-Process -Name Spotify
 Stop-Process -Name SpotifyWebHelper
 
+if ($PSVersionTable.PSVersion.Major -ge 7)
+{
+    Import-Module Appx -UseWindowsPowerShell
+}
+
 if (Get-AppxPackage -Name SpotifyAB.SpotifyMusic) {
   Write-Host @'
 The Microsoft Store version of Spotify has been detected which is not supported.


### PR DESCRIPTION
Fix PS v7 compatibility

This fixes PowerShell +v7.0.0 compatibility issue by loading explicitly AppX module into the session with the compatibility flag.

## Note
The install PS script is a rubbish. If you are interested in refactoring into a proper, maintainable code, please, let me know.