### PR TITLE
Patch to remove ad placeholder

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -181,9 +181,9 @@ if ($ch -eq 'y') {
     $xpuiContents = $reader.ReadToEnd()
     $reader.Close()
 
-    # Replace ".ads.leaderboard.isEnabled}"
-    # With ".ads.leaderboard.isEnabled&&false}"
-    $xpuiContents = $xpuiContents -replace '(\.ads\.leaderboard\.isEnabled)}', '$1&&false}'
+    # Replace ".ads.leaderboard.isEnabled" + separator - '}' or ')'
+    # With ".ads.leaderboard.isEnabled&&false" + separator
+    $xpuiContents = $xpuiContents -replace '(\.ads\.leaderboard\.isEnabled)(}|\))', '$1&&false$2'
 
     # Rewrite it to the zip
     $writer = New-Object System.IO.StreamWriter($entry.Open())

--- a/install.ps1
+++ b/install.ps1
@@ -181,12 +181,12 @@ if ($ch -eq 'y') {
     $xpuiContents = $reader.ReadToEnd()
     $reader.Close()
 
-    # Replace ".ads.leaderboard.isEnabled}
+    # Replace ".ads.leaderboard.isEnabled}"
     # With ".ads.leaderboard.isEnabled&&false}"
     $xpuiContents = $xpuiContents -replace '(\.ads\.leaderboard\.isEnabled)}', '$1&&false}'
 
     # Rewrite it to the zip
-    $writer = New-object System.IO.StreamWriter($entry.Open())
+    $writer = New-Object System.IO.StreamWriter($entry.Open())
     $writer.BaseStream.SetLength(0)
     $writer.Write($xpuiContents)
     $writer.Close()

--- a/install.ps1
+++ b/install.ps1
@@ -167,6 +167,37 @@ UI isn't changed.
 }
 #>
 
+$ch = Read-Host -Prompt "Optional - Remove ad placeholder. (Experimental) (Y/N) "
+if ($ch -eq 'y') {
+    Add-Type -Assembly 'System.IO.Compression.FileSystem'
+
+    Copy-Item -Path "$SpotifyApps\xpui.spa" -Destination "$SpotifyApps\xpui.spa.bak"
+
+    $zip = [System.IO.Compression.ZipFile]::Open("$SpotifyApps\xpui.spa", 'update')
+    $entry = $zip.GetEntry('xpui.js')
+
+    # Extract xpui.js from zip to memory
+    $reader = New-Object System.IO.StreamReader($entry.Open())
+    $xpuiContents = $reader.ReadToEnd()
+    $reader.Close()
+
+    # Replace ".ads.leaderboard.isEnabled}
+    # With ".ads.leaderboard.isEnabled&&false}"
+    $xpuiContents = $xpuiContents -replace '(\.ads\.leaderboard\.isEnabled)}', '$1&&false}'
+
+    # Rewrite it to the zip
+    $writer = New-object System.IO.StreamWriter($entry.Open())
+    $writer.BaseStream.SetLength(0)
+    $writer.Write($xpuiContents)
+    $writer.Close()
+
+    $zip.Dispose()
+} else {
+     Write-Host @'
+Won't remove ad placeholder.
+'@`n
+}
+
 $tempDirectory = $PWD
 Pop-Location
 


### PR DESCRIPTION
Based on https://github.com/mrpond/BlockTheSpot/issues/150#issuecomment-903240079

Not sure if this is "safe" but it seems to work nicely.

I'm also not sure about how to do the backup, because if the script is run twice, it will silently overwrite the older one...