### PR TITLE
Fix banner/upgrade button patch for spicetify

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -191,6 +191,8 @@ if ($ch -eq 'y') {
     } elseif (Test-Path $xpuiUnpackedPath) {
         Copy-Item -Path $xpuiUnpackedPath -Destination "$xpuiUnpackedPath.bak"
         $xpuiContents = Get-Content -Path $xpuiUnpackedPath -Raw
+
+        Write-Host 'Spicetify detected - You may need to reinstall BTS after running "spicetify apply".';
     } else {
         Write-Host 'Could not find xpui.js, please open an issue on the BlockTheSpot repository.'
     }

--- a/install.ps1
+++ b/install.ps1
@@ -169,12 +169,11 @@ UI isn't changed.
 
 $ch = Read-Host -Prompt "Optional - Remove ad placeholder and upgrade button. (Y/N) "
 if ($ch -eq 'y') {
-    # Try to read xpui.js from xpui.spa for normal Spotify installations, or
-    # directly from Apps/xpui/xpui.js in case Spicetify is installed.
-    
     $xpuiBundlePath = "$SpotifyApps\xpui.spa"
     $xpuiUnpackedPath = "$SpotifyApps\xpui\xpui.js"
     
+    # Try to read xpui.js from xpui.spa for normal Spotify installations, or
+    # directly from Apps/xpui/xpui.js in case Spicetify is installed.
     if (Test-Path $xpuiBundlePath) {
         Add-Type -Assembly 'System.IO.Compression.FileSystem'
         Copy-Item -Path $xpuiBundlePath -Destination "$xpuiBundlePath.bak"

--- a/install.ps1
+++ b/install.ps1
@@ -167,34 +167,52 @@ UI isn't changed.
 }
 #>
 
-$ch = Read-Host -Prompt "Optional - Remove ad placeholder and upgrade button. Press 'N' if using Spicetify (Y/N) "
+$ch = Read-Host -Prompt "Optional - Remove ad placeholder and upgrade button. (Y/N) "
 if ($ch -eq 'y') {
-    Add-Type -Assembly 'System.IO.Compression.FileSystem'
-
-    Copy-Item -Path "$SpotifyApps\xpui.spa" -Destination "$SpotifyApps\xpui.spa.bak"
-
-    $zip = [System.IO.Compression.ZipFile]::Open("$SpotifyApps\xpui.spa", 'update')
-    $entry = $zip.GetEntry('xpui.js')
-
-    # Extract xpui.js from zip to memory
-    $reader = New-Object System.IO.StreamReader($entry.Open())
-    $xpuiContents = $reader.ReadToEnd()
-    $reader.Close()
-
-    # Replace ".ads.leaderboard.isEnabled" + separator - '}' or ')'
-    # With ".ads.leaderboard.isEnabled&&false" + separator
-    $xpuiContents = $xpuiContents -replace '(\.ads\.leaderboard\.isEnabled)(}|\))', '$1&&false$2'
+    # Try to read xpui.js from xpui.spa for normal Spotify installations, or
+    # directly from Apps/xpui/xpui.js in case Spicetify is installed.
     
-    # Delete ".createElement(XX,{onClick:X,className:XX.X.UpgradeButton}),X()"
-    $xpuiContents = $xpuiContents -replace '\.createElement\([^.,{]+,{onClick:[^.,]+,className:[^.]+\.[^.]+\.UpgradeButton}\),[^.(]+\(\)', ''
+    $xpuiBundlePath = "$SpotifyApps\xpui.spa"
+    $xpuiUnpackedPath = "$SpotifyApps\xpui\xpui.js"
     
-    # Rewrite it to the zip
-    $writer = New-Object System.IO.StreamWriter($entry.Open())
-    $writer.BaseStream.SetLength(0)
-    $writer.Write($xpuiContents)
-    $writer.Close()
+    if (Test-Path $xpuiBundlePath) {
+        Add-Type -Assembly 'System.IO.Compression.FileSystem'
+        Copy-Item -Path $xpuiBundlePath -Destination "$xpuiBundlePath.bak"
 
-    $zip.Dispose()
+        $zip = [System.IO.Compression.ZipFile]::Open($xpuiBundlePath, 'update')
+        $entry = $zip.GetEntry('xpui.js')
+
+        # Extract xpui.js from zip to memory
+        $reader = New-Object System.IO.StreamReader($entry.Open())
+        $xpuiContents = $reader.ReadToEnd()
+        $reader.Close()
+    } elseif (Test-Path $xpuiUnpackedPath) {
+        Copy-Item -Path $xpuiUnpackedPath -Destination "$xpuiUnpackedPath.bak"
+        $xpuiContents = Get-Content -Path $xpuiUnpackedPath -Raw
+    } else {
+        Write-Host 'Could not find xpui.js, please open an issue on the BlockTheSpot repository.'
+    }
+
+    if ($xpuiContents) {
+        # Replace ".ads.leaderboard.isEnabled" + separator - '}' or ')'
+        # With ".ads.leaderboard.isEnabled&&false" + separator
+        $xpuiContents = $xpuiContents -replace '(\.ads\.leaderboard\.isEnabled)(}|\))', '$1&&false$2'
+    
+        # Delete ".createElement(XX,{onClick:X,className:XX.X.UpgradeButton}),X()"
+        $xpuiContents = $xpuiContents -replace '\.createElement\([^.,{]+,{onClick:[^.,]+,className:[^.]+\.[^.]+\.UpgradeButton}\),[^.(]+\(\)', ''
+    
+        if ($zip) {
+            # Rewrite it to the zip
+            $writer = New-Object System.IO.StreamWriter($entry.Open())
+            $writer.BaseStream.SetLength(0)
+            $writer.Write($xpuiContents)
+            $writer.Close()
+
+            $zip.Dispose()
+        } else {
+            Set-Content -Path $xpuiUnpackedPath -Value $xpuiContents
+        }
+    }
 } else {
      Write-Host @'
 Won't remove ad placeholder and upgrade button.

--- a/install.ps1
+++ b/install.ps1
@@ -171,6 +171,7 @@ $ch = Read-Host -Prompt "Optional - Remove ad placeholder and upgrade button. (Y
 if ($ch -eq 'y') {
     $xpuiBundlePath = "$SpotifyApps\xpui.spa"
     $xpuiUnpackedPath = "$SpotifyApps\xpui\xpui.js"
+    $fromZip = $false
     
     # Try to read xpui.js from xpui.spa for normal Spotify installations, or
     # directly from Apps/xpui/xpui.js in case Spicetify is installed.
@@ -185,6 +186,8 @@ if ($ch -eq 'y') {
         $reader = New-Object System.IO.StreamReader($entry.Open())
         $xpuiContents = $reader.ReadToEnd()
         $reader.Close()
+
+        $fromZip = $true
     } elseif (Test-Path $xpuiUnpackedPath) {
         Copy-Item -Path $xpuiUnpackedPath -Destination "$xpuiUnpackedPath.bak"
         $xpuiContents = Get-Content -Path $xpuiUnpackedPath -Raw
@@ -200,7 +203,7 @@ if ($ch -eq 'y') {
         # Delete ".createElement(XX,{onClick:X,className:XX.X.UpgradeButton}),X()"
         $xpuiContents = $xpuiContents -replace '\.createElement\([^.,{]+,{onClick:[^.,]+,className:[^.]+\.[^.]+\.UpgradeButton}\),[^.(]+\(\)', ''
     
-        if ($zip) {
+        if ($fromZip) {
             # Rewrite it to the zip
             $writer = New-Object System.IO.StreamWriter($entry.Open())
             $writer.BaseStream.SetLength(0)


### PR DESCRIPTION
This PR adds support for Spicetify in the patch that removes the ad banner/upgrade button.