### PR TITLE
Fix #291 TSL12 handling

### DIFF
--- a/BlockTheSpot.bat
+++ b/BlockTheSpot.bat
@@ -1,4 +1,4 @@
 @echo off
-powershell -Command "& {Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/mrpond/BlockTheSpot/master/install.ps1' | Invoke-Expression}"
+powershell -Command "& {[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/mrpond/BlockTheSpot/master/install.ps1' | Invoke-Expression}"
 pause
 exit

--- a/install.ps1
+++ b/install.ps1
@@ -27,6 +27,7 @@ function Get-File
         $Timeout = 10000
     )
 
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     $useBitTransfer = $null -ne (Get-Module -Name BitsTransfer -ListAvailable) -and ($PSVersionTable.PSVersion.Major -le 5)
 
     if ($useBitTransfer)

--- a/install.ps1
+++ b/install.ps1
@@ -2,57 +2,72 @@
 $PSDefaultParameterValues['Stop-Process:ErrorAction'] = [System.Management.Automation.ActionPreference]::SilentlyContinue
 function Get-File
 {
-  param (
-    [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
-    [ValidateNotNullOrEmpty()]
-    [System.Uri]
-    $Uri,
-    [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
-    [ValidateNotNullOrEmpty()]
-    [System.IO.FileInfo]
-    $TargetFile,
-    [Parameter(ValueFromPipelineByPropertyName)]
-    [ValidateNotNullOrEmpty()]
-    [Int32]
-    $BufferSize = 1,
-    [Parameter(ValueFromPipelineByPropertyName)]
-    [ValidateNotNullOrEmpty()]
-    [ValidateSet('KB, MB')]
-    [String]
-    $BufferUnit = 'MB'
-  )
+    param (
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
+        [System.Uri]
+        $Uri,
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
+        [System.IO.FileInfo]
+        $TargetFile,
+        [Parameter(ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
+        [Int32]
+        $BufferSize = 1,
+        [Parameter(ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
+        [ValidateSet('KB, MB')]
+        [String]
+        $BufferUnit = 'MB',
+        [Parameter(ValueFromPipelineByPropertyName)]
+        [ValidateNotNullOrEmpty()]
+        [ValidateSet('KB, MB')]
+        [Int32]
+        $Timeout = 10000
+    )
 
-  $request = [System.Net.HttpWebRequest]::Create($Uri)
-  $request.set_Timeout(15000) #15 second timeout
-  $response = $request.GetResponse()
-  $totalLength = [System.Math]::Floor($response.get_ContentLength() / 1024)
-  $responseStream = $response.GetResponseStream()
-  $targetStream = New-Object -TypeName ([System.IO.FileStream]) -ArgumentList "$($TargetFile.FullName)", Create
-  switch ($BufferUnit)
-  {
-    'KB' { $BufferSize = $BufferSize * 1024 }
-    'MB' { $BufferSize = $BufferSize * 1024 * 1024 }
-    Default { $BufferSize = 1024 * 1024 }
-  }
-  Write-Verbose -Message "Buffer size: $BufferSize B ($($BufferSize/("1$BufferUnit")) $BufferUnit)"
-  $buffer = New-Object byte[] $BufferSize
-  $count = $responseStream.Read($buffer, 0, $buffer.length)
-  $downloadedBytes = $count
+    $useBitTransfer = $null -ne (Get-Module -Name BitsTransfer -ListAvailable) -and ($PSVersionTable.PSVersion.Major -le 5)
 
-  while ($count -gt 0)
-  {
-    $targetStream.Write($buffer, 0, $count)
-    $count = $responseStream.Read($buffer, 0, $buffer.length)
-    $downloadedBytes = $downloadedBytes + $count
-    Write-Progress -Activity "Downloading file '$($Uri.ToString().split('/') | Select-Object -Last 1)'" -Status "Downloaded ($([System.Math]::Floor($downloadedBytes/1024))K of $($totalLength)K): " -PercentComplete ((([System.Math]::Floor($downloadedBytes / 1024)) / $totalLength) * 100)
-  }
+    if ($useBitTransfer)
+    {
+        Write-Information -MessageData 'Using a fallback BitTransfer method since you are running Windows PowerShell'
+        Start-BitsTransfer -Source $Uri -Destination "$($TargetFile.FullName)"
+    }
+    else
+    {
+        $request = [System.Net.HttpWebRequest]::Create($Uri)
+        $request.set_Timeout($Timeout) #15 second timeout
+        $response = $request.GetResponse()
+        $totalLength = [System.Math]::Floor($response.get_ContentLength() / 1024)
+        $responseStream = $response.GetResponseStream()
+        $targetStream = New-Object -TypeName ([System.IO.FileStream]) -ArgumentList "$($TargetFile.FullName)", Create
+        switch ($BufferUnit)
+        {
+            'KB' { $BufferSize = $BufferSize * 1024 }
+            'MB' { $BufferSize = $BufferSize * 1024 * 1024 }
+            Default { $BufferSize = 1024 * 1024 }
+        }
+        Write-Verbose -Message "Buffer size: $BufferSize B ($($BufferSize/("1$BufferUnit")) $BufferUnit)"
+        $buffer = New-Object byte[] $BufferSize
+        $count = $responseStream.Read($buffer, 0, $buffer.length)
+        $downloadedBytes = $count
+        $downloadedFileName = $Uri -split '/' | Select-Object -Last 1
+        while ($count -gt 0)
+        {
+            $targetStream.Write($buffer, 0, $count)
+            $count = $responseStream.Read($buffer, 0, $buffer.length)
+            $downloadedBytes = $downloadedBytes + $count
+            Write-Progress -Activity "Downloading file '$downloadedFileName'" -Status "Downloaded ($([System.Math]::Floor($downloadedBytes/1024))K of $($totalLength)K): " -PercentComplete ((([System.Math]::Floor($downloadedBytes / 1024)) / $totalLength) * 100)
+        }
 
-  Write-Progress -Activity "Finished downloading file '$($Uri.ToString().split('/') | Select-Object -Last 1)'"
+        Write-Progress -Activity "Finished downloading file '$downloadedFileName'"
 
-  $targetStream.Flush()
-  $targetStream.Close()
-  $targetStream.Dispose()
-  $responseStream.Dispose()
+        $targetStream.Flush()
+        $targetStream.Close()
+        $targetStream.Dispose()
+        $responseStream.Dispose()
+    }
 }
 
 Write-Host @'
@@ -68,8 +83,6 @@ Write-Host @'
 Author: @Nuzair46
 *****************
 '@
-
-$useBitTransfer = $null -ne (Get-Module -Name BitsTransfer -ListAvailable) -and ($PSVersionTable.PSVersion.Major -le 5)
 
 $spotifyDirectory = Join-Path -Path $env:APPDATA -ChildPath 'Spotify'
 $spotifyExecutable = Join-Path -Path $spotifyDirectory -ChildPath 'Spotify.exe'
@@ -121,14 +134,7 @@ $elfPath = Join-Path -Path $PWD -ChildPath 'chrome_elf.zip'
 try
 {
   $uri = 'https://github.com/mrpond/BlockTheSpot/releases/latest/download/chrome_elf.zip'
-  if ($useBitTransfer)
-  {
-    Start-BitsTransfer -Source $uri -Destination "$elfPath"
-  }
-  else
-  {
-    Get-File -Uri $uri -TargetFile "$elfPath"
-  }
+  Get-File -Uri $uri -TargetFile "$elfPath"
 }
 catch
 {
@@ -164,14 +170,7 @@ if (-not $spotifyInstalled -or $update)
   try
   {
     $uri = 'https://download.scdn.co/SpotifyFullSetup.exe'
-    if ($useBitTransfer)
-    {
-      Start-BitsTransfer -Source $uri -Destination "$spotifySetupFilePath"
-    }
-    else
-    {
-      Get-File -Uri $uri -TargetFile "$spotifySetupFilePath"
-    }
+    Get-File -Uri $uri -TargetFile "$spotifySetupFilePath"
   }
   catch
   {

--- a/install.ps1
+++ b/install.ps1
@@ -80,7 +80,7 @@ Please retweet these hashtag, help me stop dictator government!
 
 Write-Host @'
 *****************
-Author: @Nuzair46
+Authors: @Nuzair46, @KUTlime
 *****************
 '@
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,59 @@
 # Ignore errors from `Stop-Process`
 $PSDefaultParameterValues['Stop-Process:ErrorAction'] = [System.Management.Automation.ActionPreference]::SilentlyContinue
+function Get-File
+{
+  param (
+    [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+    [ValidateNotNullOrEmpty()]
+    [System.Uri]
+    $Uri,
+    [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+    [ValidateNotNullOrEmpty()]
+    [System.IO.FileInfo]
+    $TargetFile,
+    [Parameter(ValueFromPipelineByPropertyName)]
+    [ValidateNotNullOrEmpty()]
+    [Int32]
+    $BufferSize = 1,
+    [Parameter(ValueFromPipelineByPropertyName)]
+    [ValidateNotNullOrEmpty()]
+    [ValidateSet('KB, MB')]
+    [String]
+    $BufferUnit = 'MB'
+  )
+
+  $request = [System.Net.HttpWebRequest]::Create($Uri)
+  $request.set_Timeout(15000) #15 second timeout
+  $response = $request.GetResponse()
+  $totalLength = [System.Math]::Floor($response.get_ContentLength() / 1024)
+  $responseStream = $response.GetResponseStream()
+  $targetStream = New-Object -TypeName ([System.IO.FileStream]) -ArgumentList "$($TargetFile.FullName)", Create
+  switch ($BufferUnit)
+  {
+    'KB' { $BufferSize = $BufferSize * 1024 }
+    'MB' { $BufferSize = $BufferSize * 1024 * 1024 }
+    Default { $BufferSize = 1024 * 1024 }
+  }
+  Write-Verbose -Message "Buffer size: $BufferSize B ($($BufferSize/("1$BufferUnit")) $BufferUnit)"
+  $buffer = New-Object byte[] $BufferSize
+  $count = $responseStream.Read($buffer, 0, $buffer.length)
+  $downloadedBytes = $count
+
+  while ($count -gt 0)
+  {
+    $targetStream.Write($buffer, 0, $count)
+    $count = $responseStream.Read($buffer, 0, $buffer.length)
+    $downloadedBytes = $downloadedBytes + $count
+    Write-Progress -Activity "Downloading file '$($Uri.ToString().split('/') | Select-Object -Last 1)'" -Status "Downloaded ($([System.Math]::Floor($downloadedBytes/1024))K of $($totalLength)K): " -PercentComplete ((([System.Math]::Floor($downloadedBytes / 1024)) / $totalLength) * 100)
+  }
+
+  Write-Progress -Activity "Finished downloading file '$($Uri.ToString().split('/') | Select-Object -Last 1)'"
+
+  $targetStream.Flush()
+  $targetStream.Close()
+  $targetStream.Dispose()
+  $responseStream.Dispose()
+}
 
 Write-Host @'
 *****************
@@ -63,7 +117,6 @@ catch
 }
 
 Write-Host "Downloading latest patch (chrome_elf.zip)...`n"
-$webClient = New-Object -TypeName ([System.Net.WebClient])
 $elfPath = Join-Path -Path $PWD -ChildPath 'chrome_elf.zip'
 try
 {
@@ -74,12 +127,7 @@ try
   }
   else
   {
-    $webClient.DownloadFile(
-      # Remote file URL
-      $uri,
-      # Local file path
-      "$elfPath"
-    )
+    Get-File -Uri $uri -TargetFile "$elfPath"
   }
 }
 catch
@@ -122,12 +170,7 @@ if (-not $spotifyInstalled -or $update)
     }
     else
     {
-      $webClient.DownloadFile(
-        # Remote file URL
-        $uri,
-        # Local file path
-        "$spotifySetupFilePath"
-      )
+      Get-File -Uri $uri -TargetFile "$spotifySetupFilePath"
     }
   }
   catch

--- a/install.ps1
+++ b/install.ps1
@@ -69,7 +69,7 @@ Author: @Nuzair46
 *****************
 '@
 
-$useBitTransfer = $null -ne (Get-Module -Name BitsTransfer -ListAvailable)
+$useBitTransfer = $null -ne (Get-Module -Name BitsTransfer -ListAvailable) -and ($PSVersionTable.PSVersion.Major -le 5)
 
 $spotifyDirectory = Join-Path -Path $env:APPDATA -ChildPath 'Spotify'
 $spotifyExecutable = Join-Path -Path $spotifyDirectory -ChildPath 'Spotify.exe'

--- a/install.ps1
+++ b/install.ps1
@@ -15,6 +15,8 @@ Author: @Nuzair46
 *****************
 '@
 
+$useBitTransfer = $null -ne (Get-Module -Name BitsTransfer -ListAvailable)
+
 $SpotifyDirectory = Join-Path -Path $env:APPDATA -ChildPath 'Spotify'
 $SpotifyExecutable = Join-Path -Path $SpotifyDirectory -ChildPath 'Spotify.exe'
 $SpotifyApps = Join-Path -Path $SpotifyDirectory -ChildPath 'Apps'
@@ -65,12 +67,20 @@ $webClient = New-Object -TypeName ([System.Net.WebClient])
 $elfPath = Join-Path -Path $PWD -ChildPath 'chrome_elf.zip'
 try
 {
-  $webClient.DownloadFile(
-    # Remote file URL
-    'https://github.com/mrpond/BlockTheSpot/releases/latest/download/chrome_elf.zip',
-    # Local file path
-    "$elfPath"
-  )
+  $uri = 'https://github.com/mrpond/BlockTheSpot/releases/latest/download/chrome_elf.zip'
+  if ($useBitTransfer)
+  {
+    Start-BitsTransfer -Source $uri -Destination "$elfPath"
+  }
+  else
+  {
+    $webClient.DownloadFile(
+      # Remote file URL
+      $uri,
+      # Local file path
+      "$elfPath"
+    )
+  }
 }
 catch
 {
@@ -101,16 +111,24 @@ else
 }
 if (-not $spotifyInstalled -or $update)
 {
-  Write-Host 'Downloading Latest Spotify full setup, please wait...'
+  Write-Host 'Downloading the latest Spotify full setup, please wait...'
   $spotifySetupFilePath = Join-Path -Path $PWD -ChildPath 'SpotifyFullSetup.exe'
   try
   {
-    $webClient.DownloadFile(
-      # Remote file URL
-      'https://download.scdn.co/SpotifyFullSetup.exe',
-      # Local file path
-      "$spotifySetupFilePath"
-    )
+    $uri = 'https://download.scdn.co/SpotifyFullSetup.exe'
+    if ($useBitTransfer)
+    {
+      Start-BitsTransfer -Source $uri -Destination "$spotifySetupFilePath"
+    }
+    else
+    {
+      $webClient.DownloadFile(
+        # Remote file URL
+        $uri,
+        # Local file path
+        "$spotifySetupFilePath"
+      )
+    }
   }
   catch
   {
@@ -147,7 +165,8 @@ if (-not $spotifyInstalled -or $update)
 
   while ($null -eq (Get-Process -Name Spotify -ErrorAction SilentlyContinue))
   {
-    #waiting until installation complete
+    # Waiting until installation complete
+    Start-Sleep -Milliseconds 100
   }
   Write-Host 'Stopping Spotify...Again'
 

--- a/install.ps1
+++ b/install.ps1
@@ -17,9 +17,9 @@ Author: @Nuzair46
 
 $useBitTransfer = $null -ne (Get-Module -Name BitsTransfer -ListAvailable)
 
-$SpotifyDirectory = Join-Path -Path $env:APPDATA -ChildPath 'Spotify'
-$SpotifyExecutable = Join-Path -Path $SpotifyDirectory -ChildPath 'Spotify.exe'
-$SpotifyApps = Join-Path -Path $SpotifyDirectory -ChildPath 'Apps'
+$spotifyDirectory = Join-Path -Path $env:APPDATA -ChildPath 'Spotify'
+$spotifyExecutable = Join-Path -Path $spotifyDirectory -ChildPath 'Spotify.exe'
+$spotifyApps = Join-Path -Path $spotifyDirectory -ChildPath 'Apps'
 
 Write-Host "Stopping Spotify...`n"
 Stop-Process -Name Spotify
@@ -91,7 +91,7 @@ catch
 Expand-Archive -Force -LiteralPath "$elfPath" -DestinationPath $PWD
 Remove-Item -LiteralPath "$elfPath" -Force
 
-$spotifyInstalled = Test-Path -LiteralPath $SpotifyExecutable
+$spotifyInstalled = Test-Path -LiteralPath $spotifyExecutable
 $update = $false
 if ($spotifyInstalled)
 {
@@ -136,7 +136,7 @@ if (-not $spotifyInstalled -or $update)
     Read-Host 'Press any key to exit...'
     exit
   }
-  New-Item -Path $SpotifyDirectory -ItemType:Directory -Force | Write-Verbose
+  New-Item -Path $spotifyDirectory -ItemType:Directory -Force | Write-Verbose
 
   [System.Security.Principal.WindowsPrincipal] $principal = [System.Security.Principal.WindowsIdentity]::GetCurrent()
   $isUserAdmin = $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
@@ -174,8 +174,8 @@ if (-not $spotifyInstalled -or $update)
   Stop-Process -Name SpotifyWebHelper
   Stop-Process -Name SpotifyFullSetup
 }
-$elfDllBackFilePath = Join-Path -Path $SpotifyDirectory -ChildPath 'chrome_elf_bak.dll'
-$elfBackFilePath = Join-Path -Path $SpotifyDirectory -ChildPath 'chrome_elf.dll'
+$elfDllBackFilePath = Join-Path -Path $spotifyDirectory -ChildPath 'chrome_elf_bak.dll'
+$elfBackFilePath = Join-Path -Path $spotifyDirectory -ChildPath 'chrome_elf.dll'
 if ((Test-Path $elfDllBackFilePath) -eq $false)
 {
   Move-Item -LiteralPath "$elfBackFilePath" -Destination "$elfDllBackFilePath" | Write-Verbose
@@ -184,13 +184,13 @@ if ((Test-Path $elfDllBackFilePath) -eq $false)
 Write-Host 'Patching Spotify...'
 $patchFiles = (Join-Path -Path $PWD -ChildPath 'chrome_elf.dll'), (Join-Path -Path $PWD -ChildPath 'config.ini')
 
-Copy-Item -LiteralPath $patchFiles -Destination "$SpotifyDirectory"
+Copy-Item -LiteralPath $patchFiles -Destination "$spotifyDirectory"
 
 $ch = Read-Host -Prompt 'Optional - Remove ad placeholder and upgrade button. (Y/N)'
 if ($ch -eq 'y')
 {
-  $xpuiBundlePath = Join-Path -Path $SpotifyApps -ChildPath 'xpui.spa'
-  $xpuiUnpackedPath = Join-Path -Path (Join-Path -Path $SpotifyApps -ChildPath 'xpui') -ChildPath 'xpui.js'
+  $xpuiBundlePath = Join-Path -Path $spotifyApps -ChildPath 'xpui.spa'
+  $xpuiUnpackedPath = Join-Path -Path (Join-Path -Path $spotifyApps -ChildPath 'xpui') -ChildPath 'xpui.js'
   $fromZip = $false
 
   # Try to read xpui.js from xpui.spa for normal Spotify installations, or
@@ -259,7 +259,7 @@ Remove-Item -LiteralPath $tempDirectory -Recurse
 
 Write-Host 'Patching Complete, starting Spotify...'
 
-Start-Process -WorkingDirectory $SpotifyDirectory -FilePath $SpotifyExecutable
+Start-Process -WorkingDirectory $spotifyDirectory -FilePath $spotifyExecutable
 Write-Host 'Done.'
 
 Write-Host @'

--- a/install.ps1
+++ b/install.ps1
@@ -1,7 +1,7 @@
 # Ignore errors from `Stop-Process`
 $PSDefaultParameterValues['Stop-Process:ErrorAction'] = [System.Management.Automation.ActionPreference]::SilentlyContinue
 
-Write-Host -Object @'
+Write-Host @'
 *****************
 @mrpond message:
 #Thailand #ThaiProtest #ThailandProtest #freeYOUTH
@@ -9,7 +9,7 @@ Please retweet these hashtag, help me stop dictator government!
 *****************
 '@
 
-Write-Host -Object @'
+Write-Host @'
 *****************
 Author: @Nuzair46
 *****************
@@ -19,7 +19,7 @@ $SpotifyDirectory = Join-Path -Path $env:APPDATA -ChildPath 'Spotify'
 $SpotifyExecutable = Join-Path -Path $SpotifyDirectory -ChildPath 'Spotify.exe'
 $SpotifyApps = Join-Path -Path $SpotifyDirectory -ChildPath 'Apps'
 
-Write-Host -Object "Stopping Spotify...`n"
+Write-Host "Stopping Spotify...`n"
 Stop-Process -Name Spotify
 Stop-Process -Name SpotifyWebHelper
 
@@ -172,11 +172,11 @@ if ($ch -eq 'y')
     Copy-Item -LiteralPath $xpuiUnpackedPath -Destination "$xpuiUnpackedPath.bak"
     $xpuiContents = Get-Content -LiteralPath $xpuiUnpackedPath -Raw
 
-    Write-Host -Object 'Spicetify detected - You may need to reinstall BTS after running "spicetify apply".';
+    Write-Host 'Spicetify detected - You may need to reinstall BTS after running "spicetify apply".';
   }
   else
   {
-    Write-Host -Object 'Could not find xpui.js, please open an issue on the BlockTheSpot repository.'
+    Write-Host 'Could not find xpui.js, please open an issue on the BlockTheSpot repository.'
   }
 
   if ($xpuiContents)
@@ -206,7 +206,7 @@ if ($ch -eq 'y')
 }
 else
 {
-  Write-Host -Object "Won't remove ad placeholder and upgrade button.`n"
+  Write-Host "Won't remove ad placeholder and upgrade button.`n"
 }
 
 $tempDirectory = $PWD
@@ -214,11 +214,12 @@ Pop-Location
 
 Remove-Item -LiteralPath $tempDirectory -Recurse
 
-Write-Host -Object 'Patching Complete, starting Spotify...'
-Start-Process -WorkingDirectory $SpotifyDirectory -FilePath $SpotifyExecutable
-Write-Host -Object 'Done.'
+Write-Host 'Patching Complete, starting Spotify...'
 
-Write-Host -Object @'
+Start-Process -WorkingDirectory $SpotifyDirectory -FilePath $SpotifyExecutable
+Write-Host 'Done.'
+
+Write-Host @'
 *****************
 @mrpond message:
 #Thailand #ThaiProtest #ThailandProtest #freeYOUTH


### PR DESCRIPTION
This PR adds TLS12 handling into the `bat` file and to the main PowerShell installation file.