### PR TITLE
Create Shortcuts when Installing and Updating Spotify

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -212,6 +212,17 @@ if (-not $spotifyInstalled -or $update)
     # Waiting until installation complete
     Start-Sleep -Milliseconds 100
   }
+
+  # Create a Shortcut to Spotify in %APPDATA%\Microsoft\Windows\Start Menu\Programs and Desktop 
+  # (allows the program to be launched from search and desktop)
+  $wshShell = New-Object -comObject WScript.Shellw
+  $desktopShortcut = $wshShell.CreateShortcut("$Home\Desktop\Spotify.lnk")
+  $startMenuShortcut = $wshShell.CreateShortcut("%APPDATA%\Microsoft\Windows\Start Menu\Programs\Spotify.lnk")
+  $desktopShortcut.TargetPath = "%APPDATA%\Spotify\Spotify.exe"
+  $startMenuShortcut.TargetPath = "%APPDATA%\Spotify\Spotify.exe"
+  $desktopShortcut.Save()
+  $startMenuShortcut.Save()
+
   Write-Host 'Stopping Spotify...Again'
 
   Stop-Process -Name Spotify

--- a/install.ps1
+++ b/install.ps1
@@ -215,11 +215,11 @@ if (-not $spotifyInstalled -or $update)
 
   # Create a Shortcut to Spotify in %APPDATA%\Microsoft\Windows\Start Menu\Programs and Desktop 
   # (allows the program to be launched from search and desktop)
-  $wshShell = New-Object -comObject WScript.Shellw
+  $wshShell = New-Object -comObject WScript.Shell
   $desktopShortcut = $wshShell.CreateShortcut("$Home\Desktop\Spotify.lnk")
-  $startMenuShortcut = $wshShell.CreateShortcut("%APPDATA%\Microsoft\Windows\Start Menu\Programs\Spotify.lnk")
-  $desktopShortcut.TargetPath = "%APPDATA%\Spotify\Spotify.exe"
-  $startMenuShortcut.TargetPath = "%APPDATA%\Spotify\Spotify.exe"
+  $startMenuShortcut = $wshShell.CreateShortcut("$Home\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Spotify.lnk")
+  $desktopShortcut.TargetPath = "$Home\AppData\Roaming\Spotify\Spotify.exe"
+  $startMenuShortcut.TargetPath = "$Home\AppData\Roaming\Spotify\Spotify.exe"
   $desktopShortcut.Save()
   $startMenuShortcut.Save()
 

--- a/install.ps1
+++ b/install.ps1
@@ -146,6 +146,16 @@ Downloading Latest Spotify full setup, please wait...
   Stop-Process -Name Spotify >$null 2>&1
   Stop-Process -Name SpotifyWebHelper >$null 2>&1
   Stop-Process -Name SpotifyFullSetup >$null 2>&1
+
+  # Create a Shortcut to Spotify in %APPDATA%\Microsoft\Windows\Start Menu\Programs and Desktop 
+  # (allows the program to be launched from search and desktop)
+  $WshShell = New-Object -comObject WScript.Shellw
+  $DesktopShortcut = $WshShell.CreateShortcut("$Home\Desktop\Spotify.lnk")
+  $StartMenuShortcut = $WshShell.CreateShortcut("%APPDATA%\Microsoft\Windows\Start Menu\Programs\Spotify.lnk")
+  $DesktopShortcut.TargetPath = "%APPDATA%\Spotify\Spotify.exe"
+  $StartMenuShortcut.TargetPath = "%APPDATA%\Spotify\Spotify.exe"
+  $DesktopShortcut.Save()
+  $StartMenuShortcut.Save()
 }
 
 if (!(test-path $SpotifyDirectory/chrome_elf_bak.dll)){


### PR DESCRIPTION
Windows Search doesn't consider a program install unless there's a shortcut to it located in `C:\ProgramData\Microsoft\Windows\Start Menu\Programs`
this pull request adds shortcuts to: 
- The Start Menu (making it possible to look for spotify after installing)
- The Desktop (because most programs also create it there after being installed, users can then pin it to quick access or the taskbar and delete the desktop shortcut afterwards if they prefer)