### PR TITLE
Fix unavailable BITS service error close close #299

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -2,74 +2,74 @@
 $PSDefaultParameterValues['Stop-Process:ErrorAction'] = [System.Management.Automation.ActionPreference]::SilentlyContinue
 function Get-File
 {
-    param (
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
-        [ValidateNotNullOrEmpty()]
-        [System.Uri]
-        $Uri,
-        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
-        [ValidateNotNullOrEmpty()]
-        [System.IO.FileInfo]
-        $TargetFile,
-        [Parameter(ValueFromPipelineByPropertyName)]
-        [ValidateNotNullOrEmpty()]
-        [Int32]
-        $BufferSize = 1,
-        [Parameter(ValueFromPipelineByPropertyName)]
-        [ValidateNotNullOrEmpty()]
-        [ValidateSet('KB, MB')]
-        [String]
-        $BufferUnit = 'MB',
-        [Parameter(ValueFromPipelineByPropertyName)]
-        [ValidateNotNullOrEmpty()]
-        [ValidateSet('KB, MB')]
-        [Int32]
-        $Timeout = 10000
-    )
+  param (
+    [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+    [ValidateNotNullOrEmpty()]
+    [System.Uri]
+    $Uri,
+    [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+    [ValidateNotNullOrEmpty()]
+    [System.IO.FileInfo]
+    $TargetFile,
+    [Parameter(ValueFromPipelineByPropertyName)]
+    [ValidateNotNullOrEmpty()]
+    [Int32]
+    $BufferSize = 1,
+    [Parameter(ValueFromPipelineByPropertyName)]
+    [ValidateNotNullOrEmpty()]
+    [ValidateSet('KB, MB')]
+    [String]
+    $BufferUnit = 'MB',
+    [Parameter(ValueFromPipelineByPropertyName)]
+    [ValidateNotNullOrEmpty()]
+    [ValidateSet('KB, MB')]
+    [Int32]
+    $Timeout = 10000
+  )
 
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-    $useBitTransfer = $null -ne (Get-Module -Name BitsTransfer -ListAvailable) -and ($PSVersionTable.PSVersion.Major -le 5) -and ((Get-Service -Name BITS).StartType -ne [System.ServiceProcess.ServiceStartMode]::Disabled)
+  $useBitTransfer = $null -ne (Get-Module -Name BitsTransfer -ListAvailable) -and ($PSVersionTable.PSVersion.Major -le 5) -and ((Get-Service -Name BITS).StartType -ne [System.ServiceProcess.ServiceStartMode]::Disabled)
 
-    if ($useBitTransfer)
+  if ($useBitTransfer)
+  {
+    Write-Information -MessageData 'Using a fallback BitTransfer method since you are running Windows PowerShell'
+    Start-BitsTransfer -Source $Uri -Destination "$($TargetFile.FullName)"
+  }
+  else
+  {
+    $request = [System.Net.HttpWebRequest]::Create($Uri)
+    $request.set_Timeout($Timeout) #15 second timeout
+    $response = $request.GetResponse()
+    $totalLength = [System.Math]::Floor($response.get_ContentLength() / 1024)
+    $responseStream = $response.GetResponseStream()
+    $targetStream = New-Object -TypeName ([System.IO.FileStream]) -ArgumentList "$($TargetFile.FullName)", Create
+    switch ($BufferUnit)
     {
-        Write-Information -MessageData 'Using a fallback BitTransfer method since you are running Windows PowerShell'
-        Start-BitsTransfer -Source $Uri -Destination "$($TargetFile.FullName)"
+      'KB' { $BufferSize = $BufferSize * 1024 }
+      'MB' { $BufferSize = $BufferSize * 1024 * 1024 }
+      Default { $BufferSize = 1024 * 1024 }
     }
-    else
+    Write-Verbose -Message "Buffer size: $BufferSize B ($($BufferSize/("1$BufferUnit")) $BufferUnit)"
+    $buffer = New-Object byte[] $BufferSize
+    $count = $responseStream.Read($buffer, 0, $buffer.length)
+    $downloadedBytes = $count
+    $downloadedFileName = $Uri -split '/' | Select-Object -Last 1
+    while ($count -gt 0)
     {
-        $request = [System.Net.HttpWebRequest]::Create($Uri)
-        $request.set_Timeout($Timeout) #15 second timeout
-        $response = $request.GetResponse()
-        $totalLength = [System.Math]::Floor($response.get_ContentLength() / 1024)
-        $responseStream = $response.GetResponseStream()
-        $targetStream = New-Object -TypeName ([System.IO.FileStream]) -ArgumentList "$($TargetFile.FullName)", Create
-        switch ($BufferUnit)
-        {
-            'KB' { $BufferSize = $BufferSize * 1024 }
-            'MB' { $BufferSize = $BufferSize * 1024 * 1024 }
-            Default { $BufferSize = 1024 * 1024 }
-        }
-        Write-Verbose -Message "Buffer size: $BufferSize B ($($BufferSize/("1$BufferUnit")) $BufferUnit)"
-        $buffer = New-Object byte[] $BufferSize
-        $count = $responseStream.Read($buffer, 0, $buffer.length)
-        $downloadedBytes = $count
-        $downloadedFileName = $Uri -split '/' | Select-Object -Last 1
-        while ($count -gt 0)
-        {
-            $targetStream.Write($buffer, 0, $count)
-            $count = $responseStream.Read($buffer, 0, $buffer.length)
-            $downloadedBytes = $downloadedBytes + $count
-            Write-Progress -Activity "Downloading file '$downloadedFileName'" -Status "Downloaded ($([System.Math]::Floor($downloadedBytes/1024))K of $($totalLength)K): " -PercentComplete ((([System.Math]::Floor($downloadedBytes / 1024)) / $totalLength) * 100)
-        }
-
-        Write-Progress -Activity "Finished downloading file '$downloadedFileName'"
-
-        $targetStream.Flush()
-        $targetStream.Close()
-        $targetStream.Dispose()
-        $responseStream.Dispose()
+      $targetStream.Write($buffer, 0, $count)
+      $count = $responseStream.Read($buffer, 0, $buffer.length)
+      $downloadedBytes = $downloadedBytes + $count
+      Write-Progress -Activity "Downloading file '$downloadedFileName'" -Status "Downloaded ($([System.Math]::Floor($downloadedBytes/1024))K of $($totalLength)K): " -PercentComplete ((([System.Math]::Floor($downloadedBytes / 1024)) / $totalLength) * 100)
     }
+
+    Write-Progress -Activity "Finished downloading file '$downloadedFileName'"
+
+    $targetStream.Flush()
+    $targetStream.Close()
+    $targetStream.Dispose()
+    $responseStream.Dispose()
+  }
 }
 
 Write-Host @'

--- a/install.ps1
+++ b/install.ps1
@@ -29,7 +29,7 @@ function Get-File
 
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-    $useBitTransfer = $null -ne (Get-Module -Name BitsTransfer -ListAvailable) -and ($PSVersionTable.PSVersion.Major -le 5)
+    $useBitTransfer = $null -ne (Get-Module -Name BitsTransfer -ListAvailable) -and ($PSVersionTable.PSVersion.Major -le 5) -and ((Get-Service -Name BITS).StartType -ne [System.ServiceProcess.ServiceStartMode]::Disabled)
 
     if ($useBitTransfer)
     {
@@ -213,7 +213,7 @@ if (-not $spotifyInstalled -or $update)
     Start-Sleep -Milliseconds 100
   }
 
-  # Create a Shortcut to Spotify in %APPDATA%\Microsoft\Windows\Start Menu\Programs and Desktop 
+  # Create a Shortcut to Spotify in %APPDATA%\Microsoft\Windows\Start Menu\Programs and Desktop
   # (allows the program to be launched from search and desktop)
   $wshShell = New-Object -comObject WScript.Shell
   $desktopShortcut = $wshShell.CreateShortcut("$Home\Desktop\Spotify.lnk")

--- a/install.ps1
+++ b/install.ps1
@@ -215,11 +215,11 @@ if (-not $spotifyInstalled -or $update)
 
   # Create a Shortcut to Spotify in %APPDATA%\Microsoft\Windows\Start Menu\Programs and Desktop
   # (allows the program to be launched from search and desktop)
-  $wshShell = New-Object -comObject WScript.Shell
+  $wshShell = New-Object -ComObject WScript.Shell
   $desktopShortcut = $wshShell.CreateShortcut("$Home\Desktop\Spotify.lnk")
-  $startMenuShortcut = $wshShell.CreateShortcut("$Home\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Spotify.lnk")
-  $desktopShortcut.TargetPath = "$Home\AppData\Roaming\Spotify\Spotify.exe"
-  $startMenuShortcut.TargetPath = "$Home\AppData\Roaming\Spotify\Spotify.exe"
+  $startMenuShortcut = $wshShell.CreateShortcut("$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Spotify.lnk")
+  $desktopShortcut.TargetPath = "$env:APPDATA\Spotify\Spotify.exe"
+  $startMenuShortcut.TargetPath = "$env:APPDATA\Spotify\Spotify.exe"
   $desktopShortcut.Save()
   $startMenuShortcut.Save()
 


### PR DESCRIPTION
This PR fixes several things, but mainly focuses an error when the script is trying to use BITS service which can't be started. The service is disabled, hence can't be used. If the service is disabled, local download method is used.

* Fix #299 by preventing a use of disabled BITS service
* Fix for invalid environment variable used in #298 
* Fix formatting of custom function