### PR TITLE
fix delete upgrade button

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -283,8 +283,8 @@ if ($ch -eq 'y')
     # With ".ads.leaderboard.isEnabled&&false" + separator
     $xpuiContents = $xpuiContents -replace '(\.ads\.leaderboard\.isEnabled)(}|\))', '$1&&false$2'
 
-    # Delete ".createElement(XX,{onClick:X,className:XX.X.UpgradeButton}),X()"
-    $xpuiContents = $xpuiContents -replace '\.createElement\([^.,{]+,{onClick:[^.,]+,className:[^.]+\.[^.]+\.UpgradeButton}\),[^.(]+\(\)', ''
+    # Delete ".createElement(XX,{(spec:X),?onClick:X,className:XX.X.UpgradeButton}),X()"
+    $xpuiContents = $xpuiContents -replace '\.createElement\([^.,{]+,{(?:spec:[^.,]+,)?onClick:[^.,]+,className:[^.]+\.[^.]+\.UpgradeButton}\),[^.(]+\(\)', ''
 
     if ($fromZip)
     {


### PR DESCRIPTION
newest update broke the update button regex by adding `spec:X` to the create element function arg list

regex was updated to *optionally* support this arg (keep backward compatibility)