### PR TITLE
Fix Shortcut Errors when files already exist & migrate from $Home to $env:USERPROFILE

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -216,12 +216,23 @@ if (-not $spotifyInstalled -or $update)
   # Create a Shortcut to Spotify in %APPDATA%\Microsoft\Windows\Start Menu\Programs and Desktop
   # (allows the program to be launched from search and desktop)
   $wshShell = New-Object -ComObject WScript.Shell
-  $desktopShortcut = $wshShell.CreateShortcut("$Home\Desktop\Spotify.lnk")
-  $startMenuShortcut = $wshShell.CreateShortcut("$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Spotify.lnk")
-  $desktopShortcut.TargetPath = "$env:APPDATA\Spotify\Spotify.exe"
-  $startMenuShortcut.TargetPath = "$env:APPDATA\Spotify\Spotify.exe"
-  $desktopShortcut.Save()
-  $startMenuShortcut.Save()
+  
+  $desktopShortcutPath = "$env:USERPROFILE\Desktop\Spotify.lnk"
+  if ((Test-Path $desktopShortcutPath) -eq $false)
+  {
+    $desktopShortcut = $wshShell.CreateShortcut($desktopShortcutPath)
+    $desktopShortcut.TargetPath = "$env:APPDATA\Spotify\Spotify.exe"
+    $desktopShortcut.Save()
+  }
+
+  $startMenuShortcutPath = "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Spotify.lnk"
+  if ((Test-Path $startMenuShortcutPath) -eq $false)
+  {
+    $startMenuShortcut = $wshShell.CreateShortcut($startMenuShortcutPath)
+    $startMenuShortcut.TargetPath = "$env:APPDATA\Spotify\Spotify.exe"
+    $startMenuShortcut.Save()
+  }
+  
 
   Write-Host 'Stopping Spotify...Again'
 


### PR DESCRIPTION
Content:
- Test the desktop and startmenu Shortcut Paths before creating the actual shortcuts
- Replace `$Home` with `$env:USERPROFILE` as the former seems to have issues working correctly for some users 

Closes #304 