### PR TITLE
Add full automatization close #318

### DIFF
--- a/BlockTheSpotAutoInstall.bat
+++ b/BlockTheSpotAutoInstall.bat
@@ -1,2 +1,0 @@
-powershell -Command "Invoke-Expression ""& { $(Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/kutlime/BlockTheSpot/automatization/install.ps1') } -UninstallSpotifyStoreEdition -UpdateSpotify -RemoveAdPlaceholder"""
-exit

--- a/BlockTheSpotAutoInstall.bat
+++ b/BlockTheSpotAutoInstall.bat
@@ -1,0 +1,3 @@
+@echo off
+powershell -Command "Invoke-Expression ""& { $(Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/kutlime/BlockTheSpot/automatization/install.ps1') } -UninstallSpotifyStoreEdition -UpdateSpotify -RemoveAdPlaceholder"""
+exit

--- a/BlockTheSpotAutoInstall.bat
+++ b/BlockTheSpotAutoInstall.bat
@@ -1,3 +1,2 @@
-@echo off
 powershell -Command "Invoke-Expression ""& { $(Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/kutlime/BlockTheSpot/automatization/install.ps1') } -UninstallSpotifyStoreEdition -UpdateSpotify -RemoveAdPlaceholder"""
 exit

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 :warning: This mod is for the [**Desktop Application**](https://www.spotify.com/download/windows/) of Spotify on Windows only and **not the Microsoft Store version**.
 
-### Installation/Update:
+### User assisted Installation/Update:
 * Just download and run [BlockTheSpot.bat](https://raw.githack.com/mrpond/BlockTheSpot/master/BlockTheSpot.bat)  
 
 or
@@ -45,6 +45,24 @@ or
 2. Rename `chrome_elf.dll` to `chrome_elf_bak.dll`
 2. Download `chrome_elf.zip` from [releases](https://github.com/mrpond/BlockTheSpot/releases)
 3. Unzip `chrome_elf.dll` and `config.ini` 
+
+### Fully automated installation
+
+* Download and run [BlockTheSpotAutoInstall.bat](https://raw.githack.com/mrpond/BlockTheSpot/master/BlockTheSpotAutoInstall.bat)
+
+* Automated installation via PowerShell
+
+```powershell
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Invoke-Expression "& { $(Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/kutlime/BlockTheSpot/automatization/install.ps1') } -UninstallSpotifyStoreEdition -UpdateSpotify -RemoveAdPlaceholder"
+```
+
+To override automatically provided values to false, use ```:`$false``` syntax, see this example
+
+```powershell
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Invoke-Expression "& { $(Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/kutlime/BlockTheSpot/automatization/install.ps1') } -UninstallSpotifyStoreEdition -UpdateSpotify:`$False -RemoveAdPlaceholder"
+```
 
 ### Uninstall:
 * Just run [uninstall.bat](https://raw.githack.com/mrpond/BlockTheSpot/master/uninstall.bat)

--- a/README.md
+++ b/README.md
@@ -41,15 +41,6 @@ or
 
 or
 
-1. Browse to your Spotify installation folder `%APPDATA%\Spotify`
-2. Rename `chrome_elf.dll` to `chrome_elf_bak.dll`
-2. Download `chrome_elf.zip` from [releases](https://github.com/mrpond/BlockTheSpot/releases)
-3. Unzip `chrome_elf.dll` and `config.ini` 
-
-### Fully automated installation
-
-* Download and run [BlockTheSpotAutoInstall.bat](https://raw.githack.com/mrpond/BlockTheSpot/master/BlockTheSpotAutoInstall.bat)
-
 * Automated installation via PowerShell
 
 ```powershell
@@ -57,12 +48,12 @@ or
 Invoke-Expression "& { $(Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/kutlime/BlockTheSpot/automatization/install.ps1') } -UninstallSpotifyStoreEdition -UpdateSpotify -RemoveAdPlaceholder"
 ```
 
-To override automatically provided values to false, use ```:`$false``` syntax, see this example
+or
 
-```powershell
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-Invoke-Expression "& { $(Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/kutlime/BlockTheSpot/automatization/install.ps1') } -UninstallSpotifyStoreEdition -UpdateSpotify:`$False -RemoveAdPlaceholder"
-```
+1. Browse to your Spotify installation folder `%APPDATA%\Spotify`
+2. Rename `chrome_elf.dll` to `chrome_elf_bak.dll`
+3. Download `chrome_elf.zip` from [releases](https://github.com/mrpond/BlockTheSpot/releases)
+4. Unzip `chrome_elf.dll` and `config.ini` 
 
 ### Uninstall:
 * Just run [uninstall.bat](https://raw.githack.com/mrpond/BlockTheSpot/master/uninstall.bat)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 :warning: This mod is for the [**Desktop Application**](https://www.spotify.com/download/windows/) of Spotify on Windows only and **not the Microsoft Store version**.
 
-### User assisted Installation/Update:
+### Installation/Update:
 * Just download and run [BlockTheSpot.bat](https://raw.githack.com/mrpond/BlockTheSpot/master/BlockTheSpot.bat)  
 
 or
@@ -39,16 +39,13 @@ or
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/mrpond/BlockTheSpot/master/install.ps1' | Invoke-Expression
 ```
 
-or
-
-* Automated installation via PowerShell
+#### Automated installation via PowerShell
 
 ```powershell
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-Invoke-Expression "& { $(Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/kutlime/BlockTheSpot/automatization/install.ps1') } -UninstallSpotifyStoreEdition -UpdateSpotify -RemoveAdPlaceholder"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-Expression "& { $(Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/kutlime/BlockTheSpot/automatization/install.ps1') } -UninstallSpotifyStoreEdition -UpdateSpotify -RemoveAdPlaceholder"
 ```
 
-or
+#### Manual installation
 
 1. Browse to your Spotify installation folder `%APPDATA%\Spotify`
 2. Rename `chrome_elf.dll` to `chrome_elf_bak.dll`

--- a/install.ps1
+++ b/install.ps1
@@ -344,5 +344,3 @@ Write-Host @'
 Please retweet these hashtag, help me stop dictator government!
 *****************
 '@
-
-exit

--- a/install.ps1
+++ b/install.ps1
@@ -1,3 +1,15 @@
+param (
+  [Parameter()]
+  [switch]
+  $UninstallSpotifyStoreEdition = (Read-Host -Prompt 'Uninstall Spotify Windows Store edition if it exists (Y/N)') -eq 'y',
+  [Parameter()]
+  [switch]
+  $UpdateSpotify = (Read-Host -Prompt 'Optional - Update Spotify to the latest version. (Might already be updated). (Y/N)') -eq 'y',
+  [Parameter()]
+  [switch]
+  $RemoveAdPlaceholder = (Read-Host -Prompt 'Optional - Remove ad placeholder and upgrade button. (Y/N)') -eq 'y'
+)
+
 # Ignore errors from `Stop-Process`
 $PSDefaultParameterValues['Stop-Process:ErrorAction'] = [System.Management.Automation.ActionPreference]::SilentlyContinue
 function Get-File
@@ -103,8 +115,7 @@ if (Get-AppxPackage -Name SpotifyAB.SpotifyMusic)
 {
   Write-Host "The Microsoft Store version of Spotify has been detected which is not supported.`n"
 
-  $ch = Read-Host -Prompt 'Uninstall Spotify Windows Store edition (Y/N)'
-  if ($ch -eq 'y')
+  if ($UninstallSpotifyStoreEdition)
   {
     Write-Host "Uninstalling Spotify.`n"
     Get-AppxPackage -Name SpotifyAB.SpotifyMusic | Remove-AppxPackage
@@ -151,8 +162,7 @@ $spotifyInstalled = Test-Path -LiteralPath $spotifyExecutable
 $update = $false
 if ($spotifyInstalled)
 {
-  $ch = Read-Host -Prompt 'Optional - Update Spotify to the latest version. (Might already be updated). (Y/N)'
-  if ($ch -eq 'y')
+  if ($UpdateSpotify)
   {
     $update = $true
   }
@@ -216,7 +226,7 @@ if (-not $spotifyInstalled -or $update)
   # Create a Shortcut to Spotify in %APPDATA%\Microsoft\Windows\Start Menu\Programs and Desktop
   # (allows the program to be launched from search and desktop)
   $wshShell = New-Object -ComObject WScript.Shell
-  
+
   $desktopShortcutPath = "$env:USERPROFILE\Desktop\Spotify.lnk"
   if ((Test-Path $desktopShortcutPath) -eq $false)
   {
@@ -232,7 +242,7 @@ if (-not $spotifyInstalled -or $update)
     $startMenuShortcut.TargetPath = "$env:APPDATA\Spotify\Spotify.exe"
     $startMenuShortcut.Save()
   }
-  
+
 
   Write-Host 'Stopping Spotify...Again'
 
@@ -252,8 +262,7 @@ $patchFiles = (Join-Path -Path $PWD -ChildPath 'chrome_elf.dll'), (Join-Path -Pa
 
 Copy-Item -LiteralPath $patchFiles -Destination "$spotifyDirectory"
 
-$ch = Read-Host -Prompt 'Optional - Remove ad placeholder and upgrade button. (Y/N)'
-if ($ch -eq 'y')
+if ($RemoveAdPlaceholder)
 {
   $xpuiBundlePath = Join-Path -Path $spotifyApps -ChildPath 'xpui.spa'
   $xpuiUnpackedPath = Join-Path -Path (Join-Path -Path $spotifyApps -ChildPath 'xpui') -ChildPath 'xpui.js'


### PR DESCRIPTION
# Summary
> This PR encapsulates the ideas proposed in #318 .

## Changes:
* Enable full auto installation in the main PowerShell installation script
* Add CMD script for fully automated installation
* Add new installation possibilities to Readme

## Details
In order of backward compatibility, the existing CMD script is kept the same. Users might want to decide during installation what to do, so this option should stay.

Any input value is transformed into a boolean variable. That can be either `true`, or `false`. If no values are provided, `Read-Host` prompt is invoked. If there is the input argument mismatch, an error is thrown.

For fully automated installation, a new bash script is provided.

## Testing
The scripts were tested on Windows PowerShell and PowerShell v7.2.1.