### PR TITLE
Add automatic client update detection close #321

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ or
 * Reinstall Spotify 
 
 ### Known Issues:  
-* You may face issue [#150](https://github.com/mrpond/BlockTheSpot/issues/150). Can be fixed by enabling the experimental feature when using `BlockTheSpot.bat`.    
-* We support last 2 version of Spotify (latest + previous) only. Please check it before opening an issue.
+* You may face issue [#150](https://github.com/mrpond/BlockTheSpot/issues/150). Can be fixed by enabling the experimental feature when using `BlockTheSpot.bat`.
 
-### Additional Notes:  
+### Additional Notes:
+
+* Installation script automatically detects if your Spotify client version is supported, or not. If the version is not supported, you will be prompted to update your Spotify client. To enforce client update, supply an optional parameter `UpdateSpotify` to the installation script.
 * Remove "Upgrade" Button [#83](https://github.com/mrpond/BlockTheSpot/issues/83) and Remove "Ad Placeholder" [#150](https://github.com/mrpond/BlockTheSpot/issues/150) only works when you use any of the auto installation methods and press `y` when prompted.  
 * "chrome_elf.dll" gets replaced by the Spotify installer each time it updates, hence why you'll probably need to apply the patch again when it happens
 * [Spicetify](https://github.com/khanhas/spicetify-cli) users will need to reapply BlockTheSpot after applying a Spicetify patches.

--- a/install.ps1
+++ b/install.ps1
@@ -88,6 +88,28 @@ function Get-File
   }
 }
 
+function Test-SpotifyVersion
+{
+  param (
+      [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+      [ValidateNotNullOrEmpty()]
+      [System.Version]
+      $MinimalSupportedVersion,
+      [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+      [ValidateNotNullOrEmpty()]
+      [System.Version]
+      $MaximalSupportedVersion,
+      [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+      [System.Version]
+      $TestedVersion
+  )
+
+  process
+  {
+    return ($MinimalSupportedVersion.CompareTo($TestedVersion) -le 0) -and ($MaximalSupportedVersion.CompareTo($TestedVersion) -ge 0)
+  }
+}
+
 Write-Host @'
 *****************
 @mrpond message:

--- a/install.ps1
+++ b/install.ps1
@@ -88,17 +88,17 @@ function Get-File
 function Test-SpotifyVersion
 {
   param (
-      [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
-      [ValidateNotNullOrEmpty()]
-      [System.Version]
-      $MinimalSupportedVersion,
-      [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
-      [ValidateNotNullOrEmpty()]
-      [System.Version]
-      $MaximalSupportedVersion,
-      [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
-      [System.Version]
-      $TestedVersion
+    [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+    [ValidateNotNullOrEmpty()]
+    [System.Version]
+    $MinimalSupportedVersion,
+    [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+    [ValidateNotNullOrEmpty()]
+    [System.Version]
+    $MaximalSupportedVersion,
+    [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+    [System.Version]
+    $TestedVersion
   )
 
   process
@@ -185,6 +185,14 @@ Remove-Item -LiteralPath "$elfPath" -Force
 
 $spotifyInstalled = Test-Path -LiteralPath $spotifyExecutable
 $UpdateSpotify = ($actualSpotifyClientVersion | Test-SpotifyVersion -MinimalSupportedVersion $minimalSupportedSpotifyVersion -MaximalSupportedVersion $maximalSupportedSpotifyVersion) -eq $false
+
+if ($UpdateSpotify)
+{
+  if ((Read-Host -Prompt 'In order to install Block the Spot, your Spotify client must be updated. Do you want to continue? (Y/N)') -ne 'y')
+  {
+    exit
+  }
+}
 
 if (-not $spotifyInstalled -or $UpdateSpotify)
 {

--- a/install.ps1
+++ b/install.ps1
@@ -4,6 +4,9 @@ param (
   $UninstallSpotifyStoreEdition = (Read-Host -Prompt 'Uninstall Spotify Windows Store edition if it exists (Y/N)') -eq 'y',
   [Parameter()]
   [switch]
+  $UpdateSpotify,
+  [Parameter()]
+  [switch]
   $RemoveAdPlaceholder = (Read-Host -Prompt 'Optional - Remove ad placeholder and upgrade button. (Y/N)') -eq 'y'
 )
 
@@ -184,9 +187,9 @@ Expand-Archive -Force -LiteralPath "$elfPath" -DestinationPath $PWD
 Remove-Item -LiteralPath "$elfPath" -Force
 
 $spotifyInstalled = Test-Path -LiteralPath $spotifyExecutable
-$UpdateSpotify = ($actualSpotifyClientVersion | Test-SpotifyVersion -MinimalSupportedVersion $minimalSupportedSpotifyVersion -MaximalSupportedVersion $maximalSupportedSpotifyVersion) -eq $false
+$unsupportedClientVersion = ($actualSpotifyClientVersion | Test-SpotifyVersion -MinimalSupportedVersion $minimalSupportedSpotifyVersion -MaximalSupportedVersion $maximalSupportedSpotifyVersion) -eq $false
 
-if ($UpdateSpotify)
+if (-not $UpdateSpotify -and $unsupportedClientVersion)
 {
   if ((Read-Host -Prompt 'In order to install Block the Spot, your Spotify client must be updated. Do you want to continue? (Y/N)') -ne 'y')
   {
@@ -194,7 +197,7 @@ if ($UpdateSpotify)
   }
 }
 
-if (-not $spotifyInstalled -or $UpdateSpotify)
+if (-not $spotifyInstalled -or $UpdateSpotify -or $unsupportedClientVersion)
 {
   Write-Host 'Downloading the latest Spotify full setup, please wait...'
   $spotifySetupFilePath = Join-Path -Path $PWD -ChildPath 'SpotifyFullSetup.exe'

--- a/install.ps1
+++ b/install.ps1
@@ -4,9 +4,6 @@ param (
   $UninstallSpotifyStoreEdition = (Read-Host -Prompt 'Uninstall Spotify Windows Store edition if it exists (Y/N)') -eq 'y',
   [Parameter()]
   [switch]
-  $UpdateSpotify = (Read-Host -Prompt 'Optional - Update Spotify to the latest version. (Might already be updated). (Y/N)') -eq 'y',
-  [Parameter()]
-  [switch]
   $RemoveAdPlaceholder = (Read-Host -Prompt 'Optional - Remove ad placeholder and upgrade button. (Y/N)') -eq 'y'
 )
 
@@ -187,23 +184,9 @@ Expand-Archive -Force -LiteralPath "$elfPath" -DestinationPath $PWD
 Remove-Item -LiteralPath "$elfPath" -Force
 
 $spotifyInstalled = Test-Path -LiteralPath $spotifyExecutable
-$update = $false
-if ($spotifyInstalled)
-{
-  if ($UpdateSpotify)
-  {
-    $update = $true
-  }
-  else
-  {
-    Write-Host 'Won''t try to update Spotify.'
-  }
-}
-else
-{
-  Write-Host 'Spotify installation was not detected.'
-}
-if (-not $spotifyInstalled -or $update)
+$UpdateSpotify = ($actualSpotifyClientVersion | Test-SpotifyVersion -MinimalSupportedVersion $minimalSupportedSpotifyVersion -MaximalSupportedVersion $maximalSupportedSpotifyVersion) -eq $false
+
+if (-not $spotifyInstalled -or $UpdateSpotify)
 {
   Write-Host 'Downloading the latest Spotify full setup, please wait...'
   $spotifySetupFilePath = Join-Path -Path $PWD -ChildPath 'SpotifyFullSetup.exe'

--- a/install.ps1
+++ b/install.ps1
@@ -12,6 +12,10 @@ param (
 
 # Ignore errors from `Stop-Process`
 $PSDefaultParameterValues['Stop-Process:ErrorAction'] = [System.Management.Automation.ActionPreference]::SilentlyContinue
+
+[System.Version] $minimalSupportedSpotifyVersion = '1.1.73.517'
+[System.Version] $maximalSupportedSpotifyVersion = '1.1.78.765'
+
 function Get-File
 {
   param (

--- a/install.ps1
+++ b/install.ps1
@@ -128,6 +128,8 @@ $spotifyDirectory = Join-Path -Path $env:APPDATA -ChildPath 'Spotify'
 $spotifyExecutable = Join-Path -Path $spotifyDirectory -ChildPath 'Spotify.exe'
 $spotifyApps = Join-Path -Path $spotifyDirectory -ChildPath 'Apps'
 
+[System.Version] $actualSpotifyClientVersion = (Get-ChildItem -LiteralPath $spotifyExecutable -ErrorAction:SilentlyContinue).VersionInfo.ProductVersionRaw
+
 Write-Host "Stopping Spotify...`n"
 Stop-Process -Name Spotify
 Stop-Process -Name SpotifyWebHelper


### PR DESCRIPTION
# Summary 
> This PR brings automated detection of need to update Spotify client.

## Changes

* Remove the default value from `UpdateSpotify`
* Add minimal supported Spotify client version to the installation script
* Add maximal supported Spotify client version to the installation script
* Add Spotify client version detection
* Add Spotify client version test if the version is supported

## Details

In order to remove useless prompts to users if they want to update their Spotify client, automatic detection of Spotify client version has been implemented. This version is tested if it is supported by Block the Spot. If not, the prompt is showed. No prompt otherwise.

In order to keep the functionality introduced in #320, some flow modifications are introduced with override based on presence of `UpdateSpotify` switch parameter. 

## Supported flow

1. A user has supported version installation -> No installation download/update.
2. A user has unsupported version installation -> A user is prompted for permission to update the client.
3. Fully automated installation when `UpdateSpotify`.

