### PR TITLE
Skip Unsupported Check - Attempt 2

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -7,7 +7,10 @@ param (
   $UpdateSpotify,
   [Parameter()]
   [switch]
-  $RemoveAdPlaceholder = (Read-Host -Prompt 'Optional - Remove ad placeholder and upgrade button. (Y/N)') -eq 'y'
+  $RemoveAdPlaceholder = (Read-Host -Prompt 'Optional - Remove ad placeholder and upgrade button. (Y/N)') -eq 'y',
+  [Parameter()]
+  [switch]
+  $skipUnsupportedCheck = (Read-Host -Prompt 'Optional - Skip Unsupported Version Check (Useful if BTS Prompts you to Reinstall Spotify) (Y/N)') -eq 'y'
 )
 
 # Ignore errors from `Stop-Process`
@@ -187,7 +190,9 @@ Expand-Archive -Force -LiteralPath "$elfPath" -DestinationPath $PWD
 Remove-Item -LiteralPath "$elfPath" -Force
 
 $spotifyInstalled = Test-Path -LiteralPath $spotifyExecutable
-$unsupportedClientVersion = ($actualSpotifyClientVersion | Test-SpotifyVersion -MinimalSupportedVersion $minimalSupportedSpotifyVersion -MaximalSupportedVersion $maximalSupportedSpotifyVersion) -eq $false
+if ($skipUnsupportedCheck -eq $false) {
+    $unsupportedClientVersion = ($actualSpotifyClientVersion | Test-SpotifyVersion -MinimalSupportedVersion $minimalSupportedSpotifyVersion -MaximalSupportedVersion $maximalSupportedSpotifyVersion) -eq $false
+}
 
 if (-not $UpdateSpotify -and $unsupportedClientVersion)
 {

--- a/install.ps1
+++ b/install.ps1
@@ -190,8 +190,11 @@ Expand-Archive -Force -LiteralPath "$elfPath" -DestinationPath $PWD
 Remove-Item -LiteralPath "$elfPath" -Force
 
 $spotifyInstalled = Test-Path -LiteralPath $spotifyExecutable
-if ($skipUnsupportedCheck -eq $false) {
-    $unsupportedClientVersion = ($actualSpotifyClientVersion | Test-SpotifyVersion -MinimalSupportedVersion $minimalSupportedSpotifyVersion -MaximalSupportedVersion $maximalSupportedSpotifyVersion) -eq $false
+$unsupportedClientVersion = $false
+
+if ($skipUnsupportedCheck -eq $false)
+{
+  $unsupportedClientVersion = ($actualSpotifyClientVersion | Test-SpotifyVersion -MinimalSupportedVersion $minimalSupportedSpotifyVersion -MaximalSupportedVersion $maximalSupportedSpotifyVersion) -eq $false
 }
 
 if (-not $UpdateSpotify -and $unsupportedClientVersion)


### PR DESCRIPTION
Apologies that I have to open a new PR, I managed to mess the previous one up.
Github seemed to have messed this one up as well and shows everything as edited. To make it easier, I've appended the changes I made in the images below


![image](https://user-images.githubusercontent.com/52699291/156681312-3b9f3d4d-1e00-4a4a-9e2c-035953901eb2.png)
![image](https://user-images.githubusercontent.com/52699291/156681319-a507168f-c3bc-47f0-a6f9-273f81e76855.png)


EDIT:

The Point of this PR is to add a way to quickly reapply BTS without having to reinstall spotify, in the case that the Script has not been adjusted to the newest version yet.