### PR TITLE
Fix #342 by suppressing useless warning

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -131,7 +131,7 @@ Stop-Process -Name SpotifyWebHelper
 
 if ($PSVersionTable.PSVersion.Major -ge 7)
 {
-  Import-Module Appx -UseWindowsPowerShell
+  Import-Module Appx -UseWindowsPowerShell -SkipEditionCheck
 }
 
 if (Get-AppxPackage -Name SpotifyAB.SpotifyMusic)

--- a/install.ps1
+++ b/install.ps1
@@ -14,7 +14,6 @@ param (
 $PSDefaultParameterValues['Stop-Process:ErrorAction'] = [System.Management.Automation.ActionPreference]::SilentlyContinue
 
 [System.Version] $minimalSupportedSpotifyVersion = '1.1.73.517'
-[System.Version] $maximalSupportedSpotifyVersion = '1.1.80.699'
 
 function Get-File
 {
@@ -95,10 +94,6 @@ function Test-SpotifyVersion
     [ValidateNotNullOrEmpty()]
     [System.Version]
     $MinimalSupportedVersion,
-    [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
-    [ValidateNotNullOrEmpty()]
-    [System.Version]
-    $MaximalSupportedVersion,
     [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
     [System.Version]
     $TestedVersion
@@ -106,7 +101,7 @@ function Test-SpotifyVersion
 
   process
   {
-    return ($MinimalSupportedVersion.CompareTo($TestedVersion) -le 0) -and ($MaximalSupportedVersion.CompareTo($TestedVersion) -ge 0)
+    return ($MinimalSupportedVersion.CompareTo($TestedVersion) -le 0)
   }
 }
 
@@ -187,7 +182,7 @@ Expand-Archive -Force -LiteralPath "$elfPath" -DestinationPath $PWD
 Remove-Item -LiteralPath "$elfPath" -Force
 
 $spotifyInstalled = Test-Path -LiteralPath $spotifyExecutable
-$unsupportedClientVersion = ($actualSpotifyClientVersion | Test-SpotifyVersion -MinimalSupportedVersion $minimalSupportedSpotifyVersion -MaximalSupportedVersion $maximalSupportedSpotifyVersion) -eq $false
+$unsupportedClientVersion = ($actualSpotifyClientVersion | Test-SpotifyVersion -MinimalSupportedVersion $minimalSupportedSpotifyVersion) -eq $false
 
 if (-not $UpdateSpotify -and $unsupportedClientVersion)
 {


### PR DESCRIPTION
#Summary

> This PR removes edition check while loading of AppX module is being loaded to remove the Spotify Store version

## Changes

* Add optional parameter `-SkipEditionCheck`

## Details

Some modules for Windows PowerShell are not native compatible with PowerShell. PowerShell team came with proxy sideloading and interop based on serialization. This enables to load the module even to PowerShell >7.x.x.

The sideloading emits a warning about serialization. This warning can be removed because the required operation is pretty much simple.

## Testing

* Windows PowerShell v5.1
* PowerShell v7.2.1
