### PR TITLE
Fix #353 invalid parameter set

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -131,7 +131,7 @@ Stop-Process -Name SpotifyWebHelper
 
 if ($PSVersionTable.PSVersion.Major -ge 7)
 {
-  Import-Module Appx -UseWindowsPowerShell -SkipEditionCheck
+  Import-Module Appx -UseWindowsPowerShell -WarningAction:SilentlyContinue
 }
 
 if (Get-AppxPackage -Name SpotifyAB.SpotifyMusic)


### PR DESCRIPTION
# Summary

> This PR properly handles an edition check while loading of AppX module is being loaded to remove the Spotify Store version

## Changes

* Remove optional parameter `-SkipEditionCheck`
* Add `WarningAction:SilentyContinue` to suppress a useless warning

## Details

Some modules for Windows PowerShell are not native compatible with PowerShell. PowerShell team came with proxy sideloading and interop based on serialization. This enables to load the module even to PowerShell >7.x.x.

The sideloading emits a warning about serialization. This warning can be removed because the required operation is pretty much simple.

A change introduced in #343 created an invalid parameter set name with explicit error.

## Testing

* Windows PowerShell v5.1
* PowerShell v7.2.1