### PR TITLE
Fix regex for NavLink button

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -324,7 +324,7 @@ if ($RemoveAdPlaceholder)
     $xpuiContents = $xpuiContents -replace '\.createElement\([^.,{]+,{(?:spec:[^.,]+,)?onClick:[^.,]+,className:[^.]+\.[^.]+\.UpgradeButton}\),[^.(]+\(\)', ''
 
     # Disable Premium NavLink button
-    $xpuiContents = $xpuiContents -replace '(const|var) .=.\?(`.*?`|"".concat\(.\).concat\(.\)):.;return .\(\)\.createElement\(".",.\(\)\(\{\},.,\{ref:.,href:.,target:"_blank",rel:"noopener nofollow"\}\),.\)', ''
+    $xpuiContents = $xpuiContents -replace 'return (.\(\).createElement\("a".+?"noopener nofollow")', '$1'
 
     if ($fromZip)
     {


### PR DESCRIPTION
Fix regex disable premium NavLink button for  `1.1.82-1.1.83+`
And also backward compatibility for outdated versions is preserved.
