### PR TITLE
Automatically update "Last Updated" in README

### DIFF
--- a/.github/workflows/last-updated.yml
+++ b/.github/workflows/last-updated.yml
@@ -1,0 +1,26 @@
+# This workflow automatically update 'Last updated' in README.md when src is modified
+
+name: Update 'Last updated' in README.md
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths: [src/**]
+
+jobs:
+  update-last-updated:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: update 'Last updated' in README.md
+        run: sed -i "/<strong>Last updated:<\/strong> /s|> .*<br>|> $(date +"%d %B %Y")<br>|" README.md
+
+      - name: Commit and Push README.md
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add README.md
+          git commit -m "[skip ci] [github-actions] update README.md"
+          git push


### PR DESCRIPTION
this GitHub action is run whenever source code change, will automatically update the "Last updated" in the readme

sample commit here:
https://github.com/Araxeus/BlockTheSpot/commit/76bfa6a57734b81013e22464fae2d77a0ef9a8fb
https://github.com/Araxeus/BlockTheSpot/runs/6132962769?check_suite_focus=true

notes:
* can also activate it manually for 10/10 laziness (should probably do it once after merging)
* might be better to remove the `Last tested version` line, since that one is harder to automate and no one updates it
* replace can be done with either:
  ```bash
  sed -ri "s#(<strong>Last updated:</strong> ).*(<br>)#\1$(date +"%d %B %Y")\2#" README.md
  ```
  ```bash
   sed -i "/<strong>Last updated:<\/strong> /s|> .*<br>|> $(date +"%d %B %Y")<br>|" README.md
  ```