### PR TITLE
fix error

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -268,7 +268,13 @@ Copy-Item -LiteralPath $patchFiles -Destination "$spotifyDirectory"
 $tempDirectory = $PWD
 Pop-Location
 
-Remove-Item -LiteralPath $tempDirectory -Recurse
+while ($null -ne (Get-Process -Name SpotifyFullSetupX64, SpotifyFullSetup -ErrorAction SilentlyContinue)) {
+    # Waiting until installation process completes
+    Start-Sleep -Milliseconds 100
+}
+
+Write-Host 'Cleaning up...'
+Remove-Item -LiteralPath $tempDirectory -Recurse -Force
 
 Write-Host 'Patching Complete, starting Spotify...'
 


### PR DESCRIPTION
fix this error
```powershell
Remove-Item:
Line |
 271 |  Remove-Item -LiteralPath $tempDirectory -Recurse
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | The process cannot access the file 'C:\Users\relvi\AppData\Local\Temp\BlockTheSpot-2023-08-23_17-10-41\SpotifyFullSetup.exe' because it is being used by another process.
Remove-Item:
Line |
 271 |  Remove-Item -LiteralPath $tempDirectory -Recurse
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Directory C:\Users\relvi\AppData\Local\Temp\BlockTheSpot-2023-08-23_17-10-41 cannot be removed because it is not empty.
```