### PR TITLE
Add Spicetify Install

### DIFF
--- a/BlockTheSpot + Spicetify.bat
+++ b/BlockTheSpot + Spicetify.bat
@@ -1,0 +1,7 @@
+@echo off
+powershell -Command "& {iwr -useb https://raw.githubusercontent.com/spicetify/spicetify-cli/master/install.ps1 | iex}"
+powershell -Command "& {iwr -useb https://raw.githubusercontent.com/spicetify/spicetify-marketplace/main/resources/install.ps1 | iex}"
+powershell -Command "& {[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/mrpond/BlockTheSpot/master/install.ps1' | Invoke-Expression}"
+
+pause
+exit /b

--- a/BlockTheSpot + Spicetify.bat
+++ b/BlockTheSpot + Spicetify.bat
@@ -2,6 +2,5 @@
 powershell -Command "& {iwr -useb https://raw.githubusercontent.com/spicetify/spicetify-cli/master/install.ps1 | iex}"
 powershell -Command "& {iwr -useb https://raw.githubusercontent.com/spicetify/spicetify-marketplace/main/resources/install.ps1 | iex}"
 powershell -Command "& {[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/mrpond/BlockTheSpot/master/install.ps1' | Invoke-Expression}"
-
 pause
 exit /b

--- a/README.md
+++ b/README.md
@@ -34,12 +34,6 @@ or
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-Expression "& { $(Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/mrpond/BlockTheSpot/master/install.ps1') } -UninstallSpotifyStoreEdition -UpdateSpotify"
 ```
 
-#### BlockTheSpot with Spicetify Installation/Update:
-
-* Just download and run [BlockTheSpot + Spicetify.bat](https://raw.githack.com/mrpond/BlockTheSpot/master/BlockTheSpot%20%2B%20Spicetify.bat) then answer the prompts when given
-
-or
-
 #### Manual installation
 
 1. Browse to your Spotify installation folder `%APPDATA%\Spotify`
@@ -52,6 +46,10 @@ or
 * Remove `dpapi.dll` and `config.ini` from Spotify directory.
 or
 * Reinstall Spotify
+
+#### BlockTheSpot with Spicetify Installation/Update:
+
+* Just download and run [BlockTheSpot + Spicetify.bat](https://raw.githack.com/mrpond/BlockTheSpot/master/BlockTheSpot%20%2B%20Spicetify.bat) then answer the prompts when given
 
 ### BlockTheSpot with Spicetify Uninstall:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 :warning: This mod is for the [**Desktop Application**](https://www.spotify.com/download/windows/) of Spotify on Windows only and **not the Microsoft Store version**.
 
 ### Installation/Update:
-* Just download and run [BlockTheSpot.bat](https://raw.githack.com/mrpond/BlockTheSpot/master/BlockTheSpot.bat)  
+* Just download and run [BlockTheSpot.bat](https://raw.githack.com/mrpond/BlockTheSpot/master/BlockTheSpot.bat)
 
 or
 
@@ -33,6 +33,12 @@ or
 ```powershell
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-Expression "& { $(Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/mrpond/BlockTheSpot/master/install.ps1') } -UninstallSpotifyStoreEdition -UpdateSpotify"
 ```
+
+#### BlockTheSpot with Spicetify Installation/Update:
+
+* Just download and run [BlockTheSpot + Spicetify.bat](https://raw.githack.com/mrpond/BlockTheSpot/master/BlockTheSpot%20%2B%20Spicetify.bat) then answer the prompts when given
+
+or
 
 #### Manual installation
 
@@ -46,6 +52,16 @@ or
 * Remove `dpapi.dll` and `config.ini` from Spotify directory.
 or
 * Reinstall Spotify
+
+### BlockTheSpot with Spicetify Uninstall:
+
+```powershell
+spicetify restore
+rmdir -r -fo $env:APPDATA\spicetify
+rmdir -r -fo $env:LOCALAPPDATA\spicetify
+rm -fo $env:APPDATA\spotify\dpapi.dll
+rm -fo $env:APPDATA\spotify\config.ini
+```
 
 ### Additional Notes:
 

--- a/src/BasicUtils/Utils.cpp
+++ b/src/BasicUtils/Utils.cpp
@@ -11,6 +11,7 @@
 #pragma warning(default: 4530)
 #include <codecvt>
 #include <fstream>
+#include <algorithm>
 
 namespace Utils
 {


### PR DESCRIPTION
I added a  Block The Spot + Spicetify.bat.
I modified the readme.md to have the install and uninstall instructions.
Added #include algorithm to utils.cpp as it was erroring to build in the last pr without it.
errors without the line above:
'transform': identifier not found
'search': is not a member of 'std'