### PR TITLE
Fix blank banner in Desktop app close #602

### DIFF
--- a/blockthespot_settings.json
+++ b/blockthespot_settings.json
@@ -32,51 +32,51 @@
         "Value": "none",
         "Offset": 70,
         "Fill": 0,
-        "Address": -1
+        "Address": 0
       }
     },
-    "xpui.js": {
+    "xpui-snapshot.js": {
       "adsEnabled": {
         "Signature": "adsEnabled:!0",
         "Value": "1",
         "Offset": 12,
         "Fill": 0,
-        "Address": -1
+        "Address": 287236
       },
       "ishptohidden": {
         "Signature": "isHptoHidden:!0",
         "Value": "1",
         "Offset": 14,
         "Fill": 0,
-        "Address": -1
+        "Address": 287155
       },
       "sponsorship": {
         "Signature": ".set(\"allSponsorships\",t.sponsorships)}}(e,t);",
         "Value": "\"",
         "Offset": 5,
         "Fill": 15,
-        "Address": -1
+        "Address": 285870
       },
       "skipsentry": {
         "Signature": "sentry.io",
         "Value": "localhost",
         "Offset": 0,
         "Fill": 0,
-        "Address": -1
+        "Address": 347953
       },
       "hptoEnabled": {
         "Signature": "hptoEnabled:!0",
         "Value": "1",
         "Offset": 13,
         "Fill": 0,
-        "Address": -1
+        "Address": 284941
       },
       "sp_localhost": {
         "Signature": "t?.payload.canShowAd",
         "Value": "!1",
         "Offset": 0,
         "Fill": 18,
-        "Address": -1
+        "Address": 284150
       },
       "premium_free": {
         "Signature": "\"free\"===e.session?",


### PR DESCRIPTION
## Summary

This PR updates `blockthespot_settings.json` file with new settings that block a new empty ad banner in the latest version of the Spotify desktop ad.

The configuration has been taken from #602. 

Tested on the desktop version 

```
Spotify pro Windows (64bitová verze)
1.2.64.408.g0a9b557c
xpui-snapshot_2025-05-16_1747395131143_0a9b557
cef_134.3.11+g7c94248+chromium-134.0.6998.178
Runtime: Chrome
```