### PR TITLE
Overhaul installation and uninstallation scripts #614

### DIFF
--- a/BlockTheSpot + Spicetify.bat
+++ b/BlockTheSpot + Spicetify.bat
@@ -13,7 +13,7 @@ set /p UserInput="Do you want to continue with the installation? (y/n): "
 if /i "%UserInput%"=="y" (
     echo.
     echo Downloading and running PowerShell installation script...
-    powershell -ExecutionPolicy Bypass -Command "& {try { Invoke-RestMethod -Uri 'https://raw.githubusercontent.com/Othmane-ElAlami/BlockTheSpot/master/BlockTheSpot%%20+%%20Spicetify.ps1' -UseBasicParsing | Invoke-Expression } catch { Write-Host 'Error downloading script:' $_.Exception.Message; Read-Host 'Press Enter to exit' }}"
+    powershell -ExecutionPolicy Bypass -Command "& {try { Invoke-RestMethod -Uri 'https://raw.githubusercontent.com/mrpond/BlockTheSpot/master/BlockTheSpot%%20+%%20Spicetify.ps1' -UseBasicParsing | Invoke-Expression } catch { Write-Host 'Error downloading script:' $_.Exception.Message; Read-Host 'Press Enter to exit' }}"
 ) else (
     echo.
     echo Installation cancelled.

--- a/BlockTheSpot + Spicetify.bat
+++ b/BlockTheSpot + Spicetify.bat
@@ -1,13 +1,22 @@
 @echo off
+echo ========================================
+echo  BlockTheSpot + Spicetify Installer
+echo ========================================
+echo.
+echo This script will install:
+echo - Spotify
+echo - Spicetify
+echo - BlockTheSpot
+echo.
 
-set /p UserInput= "Spicetify will be Installed. If you don't agree, use the BlockTheSpot script, else press 'y' to continue (y/n)? "
+set /p UserInput="Do you want to continue with the installation? (y/n): "
 if /i "%UserInput%"=="y" (
-    powershell -Command "& {iwr -useb https://raw.githubusercontent.com/spicetify/spicetify-cli/master/install.ps1 | iex}"
-    powershell -Command "& {iwr -useb https://raw.githubusercontent.com/spicetify/spicetify-marketplace/main/resources/install.ps1 | iex}"
-    powershell -Command "& {[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/mrpond/BlockTheSpot/master/install.ps1' | Invoke-Expression}"
-    pause
+    echo.
+    echo Downloading and running PowerShell installation script...
+    powershell -ExecutionPolicy Bypass -Command "& {try { Invoke-RestMethod -Uri 'https://raw.githubusercontent.com/Othmane-ElAlami/BlockTheSpot/master/BlockTheSpot%%20+%%20Spicetify.ps1' -UseBasicParsing | Invoke-Expression } catch { Write-Host 'Error downloading script:' $_.Exception.Message; Read-Host 'Press Enter to exit' }}"
 ) else (
-    echo "Patch not installed."
+    echo.
+    echo Installation cancelled.
     pause
     exit /b
 )

--- a/BlockTheSpot + Spicetify.ps1
+++ b/BlockTheSpot + Spicetify.ps1
@@ -1,0 +1,246 @@
+# BlockTheSpot + Spicetify Installation Script
+
+# Set error action preference
+$ErrorActionPreference = "Continue"
+
+# Function to display section headers
+function Write-SectionHeader {
+    param([string]$Message)
+    Write-Host "========================================" -ForegroundColor Blue
+    Write-Host " $Message" -ForegroundColor Cyan
+    Write-Host "========================================" -ForegroundColor Blue
+}
+
+# Function to handle errors gracefully
+function Invoke-SafeCommand {
+    param(
+        [scriptblock]$Command,
+        [string]$ErrorMessage
+    )
+    
+    try {
+        & $Command
+    }
+    catch {
+        Write-Host "$ErrorMessage $($_.Exception.Message)" -ForegroundColor Red
+        Read-Host "Press Enter to continue anyway..."
+    }
+}
+
+# Step 1: Installing BlockTheSpot
+Write-SectionHeader "Step 1: Installing BlockTheSpot"
+
+Invoke-SafeCommand -Command {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Write-Host "Downloading and running BlockTheSpot installer..." -ForegroundColor Green
+    $installScript = Invoke-RestMethod -Uri "https://raw.githubusercontent.com/Othmane-ElAlami/BlockTheSpot/master/install.ps1" -UseBasicParsing
+    Invoke-Expression "& { $installScript } -UninstallSpotifyStoreEdition"
+} -ErrorMessage "Error installing BlockTheSpot:"
+
+Write-Host ""
+
+# Step 2: Installing Spicetify CLI
+Write-SectionHeader "Step 2: Installing Spicetify CLI"
+
+Invoke-SafeCommand -Command {
+    Write-Host "Installing Spicetify CLI..." -ForegroundColor Green
+    Invoke-RestMethod -Uri "https://raw.githubusercontent.com/spicetify/spicetify-cli/master/install.ps1" -UseBasicParsing | Invoke-Expression
+} -ErrorMessage "Error installing Spicetify CLI:"
+
+Write-Host ""
+
+# Step 3: Configuring Spicetify
+Write-SectionHeader "Step 3: Configuring Spicetify"
+
+Invoke-SafeCommand -Command {
+    Write-Host "Backing up and configuring Spicetify..." -ForegroundColor Green
+    & spicetify backup
+    & spicetify config inject_css 1 replace_colors 1
+    Write-Host "Spicetify configured successfully!" -ForegroundColor Green
+} -ErrorMessage "Error configuring Spicetify:"
+
+Write-Host ""
+
+# Step 4: Installing Spicetify Marketplace
+Write-SectionHeader "Step 4: Installing Spicetify Marketplace"
+
+Invoke-SafeCommand -Command {
+    Write-Host "Installing Spicetify Marketplace..." -ForegroundColor Green
+    Invoke-RestMethod -Uri "https://raw.githubusercontent.com/spicetify/spicetify-marketplace/main/resources/install.ps1" -UseBasicParsing | Invoke-Expression
+} -ErrorMessage "Error installing Spicetify Marketplace:"
+
+Write-Host ""
+
+# Step 5: Final Application
+Write-SectionHeader "Step 5: Final Application"
+
+Invoke-SafeCommand -Command {
+    Write-Host "Applying Spicetify modifications..." -ForegroundColor Green
+    & spicetify apply
+    Write-Host "Spicetify applied successfully!" -ForegroundColor Green
+} -ErrorMessage "Error applying Spicetify:"
+
+Write-Host ""
+
+# Step 6: Re-applying BlockTheSpot
+Write-SectionHeader "Step 6: Re-applying BlockTheSpot"
+
+Invoke-SafeCommand -Command {
+    Write-Host "Re-applying BlockTheSpot after Spicetify..." -ForegroundColor Green
+    
+    $SpotifyPath = "$env:APPDATA\Spotify\"
+    
+    # Stop Spotify processes
+    Get-Process -Name "Spotify*" -ErrorAction SilentlyContinue | Stop-Process -Force
+    Start-Sleep -Seconds 2
+    
+    # Create temporary directory
+    $tempDir = "$env:TEMP\BTS-$(Get-Date -Format 'HHmmss')"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+    
+    # Download and extract BlockTheSpot
+    $zipPath = Join-Path $tempDir "chrome_elf.zip"
+    Invoke-WebRequest -Uri "https://github.com/mrpond/BlockTheSpot/releases/latest/download/chrome_elf.zip" -OutFile $zipPath -UseBasicParsing
+    Expand-Archive -Path $zipPath -DestinationPath $tempDir -Force
+    
+    # Copy files to Spotify directory
+    $dpapiSource = Join-Path $tempDir "dpapi.dll"
+    $configSource = Join-Path $tempDir "config.ini"
+    $dpapiDest = Join-Path $SpotifyPath "dpapi.dll"
+    $configDest = Join-Path $SpotifyPath "config.ini"
+    
+    Copy-Item -Path $dpapiSource -Destination $dpapiDest -Force
+    Copy-Item -Path $configSource -Destination $configDest -Force
+    
+    Write-Host "BlockTheSpot re-applied successfully!" -ForegroundColor Green
+    
+    # Clean up temporary directory
+    Remove-Item -Path $tempDir -Recurse -Force
+    
+    # Start Spotify
+    $spotifyExe = Join-Path $SpotifyPath "Spotify.exe"
+    Start-Process -FilePath $spotifyExe
+} -ErrorMessage "Error re-applying BlockTheSpot:"
+
+Write-Host ""
+
+# Step 7: Final Verification Check
+Write-SectionHeader "Step 7: Verifying Installation"
+
+function Test-InstallationStatus {
+    $verificationResults = @{
+        SpotifyInstalled     = $false
+        BlockTheSpotFiles    = $false
+        SpicetifyInstalled   = $false
+        SpicetifyConfigured  = $false
+        MarketplaceInstalled = $false
+    }
+    
+    $SpotifyPath = "$env:APPDATA\Spotify\"
+    $SpicetifyPath = "$env:APPDATA\spicetify\"
+    
+    Write-Host "Checking installation status..." -ForegroundColor Green
+    
+    # Check if Spotify is installed
+    $spotifyExe = Join-Path $SpotifyPath "Spotify.exe"
+    if (Test-Path $spotifyExe) {
+        $verificationResults.SpotifyInstalled = $true
+        Write-Host "✓ Spotify found at: $spotifyExe" -ForegroundColor Green
+    }
+    else {
+        Write-Host "✗ Spotify not found at expected location" -ForegroundColor Red
+    }
+    
+    # Check BlockTheSpot files
+    $dpapiDll = Join-Path $SpotifyPath "dpapi.dll"
+    $configIni = Join-Path $SpotifyPath "config.ini"
+    if ((Test-Path $dpapiDll) -and (Test-Path $configIni)) {
+        $verificationResults.BlockTheSpotFiles = $true
+        Write-Host "✓ BlockTheSpot files found (dpapi.dll, config.ini)" -ForegroundColor Green
+    }
+    else {
+        Write-Host "✗ BlockTheSpot files missing" -ForegroundColor Red
+        if (-not (Test-Path $dpapiDll)) { Write-Host "  - Missing: dpapi.dll" -ForegroundColor Yellow }
+        if (-not (Test-Path $configIni)) { Write-Host "  - Missing: config.ini" -ForegroundColor Yellow }
+    }
+    
+    # Check if Spicetify is installed
+    try {
+        $spicetifyVersion = & spicetify --version 2>$null
+        if ($spicetifyVersion) {
+            $verificationResults.SpicetifyInstalled = $true
+            Write-Host "✓ Spicetify CLI installed: $spicetifyVersion" -ForegroundColor Green
+        }
+    }
+    catch {
+        Write-Host "✗ Spicetify CLI not found in PATH" -ForegroundColor Red
+    }
+    
+    # Check Spicetify configuration
+    $spicetifyConfig = Join-Path $SpicetifyPath "config-xpui.ini"
+    if (Test-Path $spicetifyConfig) {
+        $configContent = Get-Content $spicetifyConfig -ErrorAction SilentlyContinue
+        $injectCss = $configContent | Select-String "inject_css\s*=\s*1"
+        $replaceColors = $configContent | Select-String "replace_colors\s*=\s*1"
+        
+        if ($injectCss -and $replaceColors) {
+            $verificationResults.SpicetifyConfigured = $true
+            Write-Host "✓ Spicetify properly configured (inject_css=1, replace_colors=1)" -ForegroundColor Green
+        }
+        else {
+            Write-Host "✗ Spicetify configuration incomplete" -ForegroundColor Red
+        }
+    }
+    else {
+        Write-Host "✗ Spicetify configuration file not found" -ForegroundColor Red
+    }
+    
+    # Check for Spicetify Marketplace
+    $marketplacePath = Join-Path $SpicetifyPath "CustomApps\marketplace"
+    if (Test-Path $marketplacePath) {
+        $verificationResults.MarketplaceInstalled = $true
+        Write-Host "✓ Spicetify Marketplace installed" -ForegroundColor Green
+    }
+    else {
+        Write-Host "✗ Spicetify Marketplace not found" -ForegroundColor Red
+    }
+    
+    return $verificationResults
+}
+
+$results = Test-InstallationStatus
+
+# Summary
+Write-Host ""
+Write-Host "Installation Summary:" -ForegroundColor Cyan
+$successCount = ($results.Values | Where-Object { $_ -eq $true }).Count
+$totalCount = $results.Count
+
+if ($successCount -eq $totalCount) {
+    Write-Host "🎉 All components successfully installed and configured! ($successCount/$totalCount)" -ForegroundColor Green
+    Write-Host "You can now enjoy ad-free Spotify with Spicetify customizations!" -ForegroundColor Green
+}
+elseif ($successCount -ge 3) {
+    Write-Host "⚠️  Most components installed successfully ($successCount/$totalCount)" -ForegroundColor Yellow
+    Write-Host "Some optional features may not be available, but core functionality should work." -ForegroundColor Yellow
+}
+else {
+    Write-Host "❌ Installation incomplete ($successCount/$totalCount)" -ForegroundColor Red
+    Write-Host "Please review the errors above and consider running the script again." -ForegroundColor Red
+}
+
+Write-Host ""
+Write-Host "Opening Spotify now..." -ForegroundColor Green
+
+# Final Spotify launch (backup in case the previous one failed)
+try {
+    $spotifyPath = Join-Path $env:APPDATA "Spotify\Spotify.exe"
+    Start-Process -FilePath $spotifyPath -ErrorAction SilentlyContinue
+}
+catch {
+    Write-Host "Could not start Spotify automatically. Please start it manually." -ForegroundColor Yellow
+}
+
+# Pause equivalent
+Write-Host "Press any key to continue..." -ForegroundColor Gray
+$null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")

--- a/BlockTheSpot + Spicetify.ps1
+++ b/BlockTheSpot + Spicetify.ps1
@@ -33,7 +33,7 @@ Write-SectionHeader "Step 1: Installing BlockTheSpot"
 Invoke-SafeCommand -Command {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     Write-Host "Downloading and running BlockTheSpot installer..." -ForegroundColor Green
-    $installScript = Invoke-RestMethod -Uri "https://raw.githubusercontent.com/Othmane-ElAlami/BlockTheSpot/master/install.ps1" -UseBasicParsing
+    $installScript = Invoke-RestMethod -Uri "https://raw.githubusercontent.com/mrpond/BlockTheSpot/master/install.ps1" -UseBasicParsing
     Invoke-Expression "& { $installScript } -UninstallSpotifyStoreEdition"
 } -ErrorMessage "Error installing BlockTheSpot:"
 

--- a/install.ps1
+++ b/install.ps1
@@ -103,9 +103,9 @@ function Test-SpotifyVersion {
 }
 
 Write-Host @'
-**********************************
-Authors: @Nuzair46, @KUTlime
-**********************************
+========================================
+Authors: @mrpond, @Nuzair46, @KUTlime
+========================================
 '@
 
 $spotifyDirectory = Join-Path -Path $env:APPDATA -ChildPath 'Spotify'
@@ -277,24 +277,6 @@ $patchFiles = (Join-Path -Path $PWD -ChildPath 'dpapi.dll'), (Join-Path -Path $P
 
 Copy-Item -LiteralPath $patchFiles -Destination "$spotifyDirectory"
 Remove-Item -LiteralPath (Join-Path -Path $spotifyDirectory -ChildPath 'blockthespot_settings.json') -Force -ErrorAction SilentlyContinue
-
-# function Install-VcRedist {
-#   $architecture = if ([Environment]::Is64BitOperatingSystem) { "x64" } else { "x86" }
-#   # https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170
-#   $vcRedistUrl = "https://aka.ms/vs/17/release/vc_redist.$($architecture).exe"
-#   $registryPath = "HKLM:\Software\Microsoft\VisualStudio\14.0\VC\Runtimes\$architecture"
-#   $installedVersion = [version]((Get-ItemProperty $registryPath -ErrorAction SilentlyContinue).Version).Substring(1)
-#   $latestVersion = [version]"14.40.33810.0"
-# 
-#   if ($installedVersion -lt $latestVersion) {
-#       $vcRedistFile = Join-Path -Path $PWD -ChildPath "vc_redist.$architecture.exe"
-#       Write-Host "Downloading and installing vc_redist.$architecture.exe..."
-#       Get-File -Uri $vcRedistUrl -TargetFile $vcRedistFile
-#       Start-Process -FilePath $vcRedistFile -ArgumentList "/install /quiet /norestart" -Wait
-#   }
-# }
-# 
-# Install-VcRedist
 
 $tempDirectory = $PWD
 Pop-Location

--- a/install.ps1
+++ b/install.ps1
@@ -12,8 +12,7 @@ $PSDefaultParameterValues['Stop-Process:ErrorAction'] = [System.Management.Autom
 
 [System.Version] $minimalSupportedSpotifyVersion = '1.2.8.923'
 
-function Get-File
-{
+function Get-File {
   param (
     [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
     [ValidateNotNullOrEmpty()]
@@ -43,21 +42,25 @@ function Get-File
 
   $useBitTransfer = $null -ne (Get-Module -Name BitsTransfer -ListAvailable) -and ($PSVersionTable.PSVersion.Major -le 5) -and ((Get-Service -Name BITS).StartType -ne [System.ServiceProcess.ServiceStartMode]::Disabled)
 
-  if ($useBitTransfer)
-  {
+  if ($useBitTransfer) {
     Write-Information -MessageData 'Using a fallback BitTransfer method since you are running Windows PowerShell'
-    Start-BitsTransfer -Source $Uri -Destination "$($TargetFile.FullName)"
+    try {
+      Start-BitsTransfer -Source $Uri -Destination "$($TargetFile.FullName)"
+    }
+    catch {
+      Write-Warning "BITS transfer failed, falling back to HTTP method: $_"
+      $useBitTransfer = $false
+    }
   }
-  else
-  {
+  
+  if (-not $useBitTransfer) {
     $request = [System.Net.HttpWebRequest]::Create($Uri)
     $request.set_Timeout($Timeout) #15 second timeout
     $response = $request.GetResponse()
     $totalLength = [System.Math]::Floor($response.get_ContentLength() / 1024)
     $responseStream = $response.GetResponseStream()
     $targetStream = New-Object -TypeName ([System.IO.FileStream]) -ArgumentList "$($TargetFile.FullName)", Create
-    switch ($BufferUnit)
-    {
+    switch ($BufferUnit) {
       'KB' { $BufferSize = $BufferSize * 1024 }
       'MB' { $BufferSize = $BufferSize * 1024 * 1024 }
       Default { $BufferSize = 1024 * 1024 }
@@ -67,8 +70,7 @@ function Get-File
     $count = $responseStream.Read($buffer, 0, $buffer.length)
     $downloadedBytes = $count
     $downloadedFileName = $Uri -split '/' | Select-Object -Last 1
-    while ($count -gt 0)
-    {
+    while ($count -gt 0) {
       $targetStream.Write($buffer, 0, $count)
       $count = $responseStream.Read($buffer, 0, $buffer.length)
       $downloadedBytes = $downloadedBytes + $count
@@ -84,8 +86,7 @@ function Get-File
   }
 }
 
-function Test-SpotifyVersion
-{
+function Test-SpotifyVersion {
   param (
     [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
     [ValidateNotNullOrEmpty()]
@@ -96,8 +97,7 @@ function Test-SpotifyVersion
     $TestedVersion
   )
 
-  process
-  {
+  process {
     return ($MinimalSupportedVersion.CompareTo($TestedVersion) -le 0)
   }
 }
@@ -110,7 +110,6 @@ Authors: @Nuzair46, @KUTlime
 
 $spotifyDirectory = Join-Path -Path $env:APPDATA -ChildPath 'Spotify'
 $spotifyExecutable = Join-Path -Path $spotifyDirectory -ChildPath 'Spotify.exe'
-$spotifyApps = Join-Path -Path $spotifyDirectory -ChildPath 'Apps'
 
 [System.Version] $actualSpotifyClientVersion = (Get-ChildItem -LiteralPath $spotifyExecutable -ErrorAction:SilentlyContinue).VersionInfo.ProductVersionRaw
 
@@ -118,37 +117,31 @@ Write-Host "Stopping Spotify...`n"
 Stop-Process -Name Spotify
 Stop-Process -Name SpotifyWebHelper
 
-if ($PSVersionTable.PSVersion.Major -ge 7)
-{
+if ($PSVersionTable.PSVersion.Major -ge 7) {
   Import-Module Appx -UseWindowsPowerShell -WarningAction:SilentlyContinue
 }
 
-if (Get-AppxPackage -Name SpotifyAB.SpotifyMusic)
-{
+if (Get-AppxPackage -Name SpotifyAB.SpotifyMusic) {
   Write-Host "The Microsoft Store version of Spotify has been detected which is not supported.`n"
 
-  if ($UninstallSpotifyStoreEdition)
-  {
+  if ($UninstallSpotifyStoreEdition) {
     Write-Host "Uninstalling Spotify.`n"
     Get-AppxPackage -Name SpotifyAB.SpotifyMusic | Remove-AppxPackage
   }
-  else
-  {
+  else {
     Read-Host "Exiting...`nPress any key to exit..."
     exit
   }
 }
 
 Push-Location -LiteralPath $env:TEMP
-try
-{
+try {
   # Unique directory name based on time
   New-Item -Type Directory -Name "BlockTheSpot-$(Get-Date -UFormat '%Y-%m-%d_%H-%M-%S')" |
   Convert-Path |
   Set-Location
 }
-catch
-{
+catch {
   Write-Output $_
   Read-Host 'Press any key to exit...'
   exit
@@ -158,33 +151,31 @@ $spotifyInstalled = Test-Path -LiteralPath $spotifyExecutable
 
 if (-not $spotifyInstalled) {
   $unsupportedClientVersion = $true
-} else {
+}
+else {
   $unsupportedClientVersion = ($actualSpotifyClientVersion | Test-SpotifyVersion -MinimalSupportedVersion $minimalSupportedSpotifyVersion) -eq $false
 }
 
-if (-not $UpdateSpotify -and $unsupportedClientVersion)
-{
-  if ((Read-Host -Prompt 'In order to install Block the Spot, your Spotify client must be updated. Do you want to continue? (Y/N)') -ne 'y')
-  {
+if (-not $UpdateSpotify -and $unsupportedClientVersion) {
+  if ((Read-Host -Prompt 'In order to install Block the Spot, your Spotify client must be updated. Do you want to continue? (Y/N)') -ne 'y') {
     exit
   }
 }
 
-if (-not $spotifyInstalled -or $UpdateSpotify -or $unsupportedClientVersion)
-{
+if (-not $spotifyInstalled -or $UpdateSpotify -or $unsupportedClientVersion) {
   Write-Host 'Downloading the latest Spotify full setup, please wait...'
   $spotifySetupFilePath = Join-Path -Path $PWD -ChildPath 'SpotifyFullSetup.exe'
-  try
-  {
-    if ([Environment]::Is64BitOperatingSystem) { # Check if the computer is running a 64-bit version of Windows
+  try {
+    if ([Environment]::Is64BitOperatingSystem) {
+      # Check if the computer is running a 64-bit version of Windows
       $uri = 'https://download.scdn.co/SpotifyFullSetupX64.exe'
-    } else {
+    }
+    else {
       $uri = 'https://download.scdn.co/SpotifyFullSetup.exe'
     }
     Get-File -Uri $uri -TargetFile "$spotifySetupFilePath"
   }
-  catch
-  {
+  catch {
     Write-Output $_
     Read-Host 'Press any key to exit...'
     exit
@@ -194,8 +185,7 @@ if (-not $spotifyInstalled -or $UpdateSpotify -or $unsupportedClientVersion)
   [System.Security.Principal.WindowsPrincipal] $principal = [System.Security.Principal.WindowsIdentity]::GetCurrent()
   $isUserAdmin = $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
   Write-Host 'Running installation...'
-  if ($isUserAdmin)
-  {
+  if ($isUserAdmin) {
     Write-Host
     Write-Host 'Creating scheduled task...'
     $apppath = 'powershell.exe'
@@ -211,13 +201,11 @@ if (-not $spotifyInstalled -or $UpdateSpotify -or $unsupportedClientVersion)
     Unregister-ScheduledTask -TaskName $taskname -Confirm:$false
     Start-Sleep -Seconds 2
   }
-  else
-  {
+  else {
     Start-Process -FilePath "$spotifySetupFilePath"
   }
 
-  while ($null -eq (Get-Process -Name Spotify -ErrorAction SilentlyContinue))
-  {
+  while ($null -eq (Get-Process -Name Spotify -ErrorAction SilentlyContinue)) {
     # Waiting until installation complete
     Start-Sleep -Milliseconds 100
   }
@@ -227,34 +215,58 @@ if (-not $spotifyInstalled -or $UpdateSpotify -or $unsupportedClientVersion)
 
   Stop-Process -Name Spotify
   Stop-Process -Name SpotifyWebHelper
-  if ([Environment]::Is64BitOperatingSystem) { # Check if the computer is running a 64-bit version of Windows
+  if ([Environment]::Is64BitOperatingSystem) {
+    # Check if the computer is running a 64-bit version of Windows
     Stop-Process -Name SpotifyFullSetupX64
-  } else {
-     Stop-Process -Name SpotifyFullSetup
+  }
+  else {
+    Stop-Process -Name SpotifyFullSetup
   }
 }
 
 Write-Host "Downloading latest patch (chrome_elf.zip)...`n"
 $elfPath = Join-Path -Path $PWD -ChildPath 'chrome_elf.zip'
-try
-{
+try {
   $bytes = [System.IO.File]::ReadAllBytes($spotifyExecutable)
   $peHeader = [System.BitConverter]::ToUInt16($bytes[0x3C..0x3D], 0)
   $is64Bit = $bytes[$peHeader + 4] -eq 0x64
 
   if ($is64Bit) {
     $uri = 'https://github.com/mrpond/BlockTheSpot/releases/latest/download/chrome_elf.zip'
-  } else {
+  }
+  else {
     Write-Host 'At the moment, the ad blocker may not work properly as the x86 architecture has not received a new update.'
     $uri = 'https://github.com/mrpond/BlockTheSpot/releases/download/2023.5.20.80/chrome_elf.zip'
   }
 
+  Write-Host "Attempting to download from: $uri"
   Get-File -Uri $uri -TargetFile "$elfPath"
+  
+  if (-not (Test-Path "$elfPath")) {
+    throw "Download failed - file does not exist at $elfPath"
+  }
+  
+  Write-Host "Download successful: $elfPath"
 }
-catch
-{
-  Write-Output $_
-  Start-Sleep
+catch {
+  Write-Output "Download error: $_"
+  Write-Host "Attempting alternative download method..."
+  try {
+    if ($is64Bit) {
+      $uri = 'https://github.com/mrpond/BlockTheSpot/releases/latest/download/chrome_elf.zip'
+    }
+    else {
+      $uri = 'https://github.com/mrpond/BlockTheSpot/releases/download/2023.5.20.80/chrome_elf.zip'
+    }
+    Invoke-WebRequest -Uri $uri -OutFile "$elfPath" -UseBasicParsing
+    Write-Host "Alternative download successful"
+  }
+  catch {
+    Write-Output "Alternative download also failed: $_"
+    Start-Sleep -Seconds 5
+    Read-Host 'Press any key to exit...'
+    exit
+  }
 }
 
 Expand-Archive -Force -LiteralPath "$elfPath" -DestinationPath $PWD

--- a/uninstall.bat
+++ b/uninstall.bat
@@ -1,11 +1,46 @@
 @echo off
-echo *****************
-echo Author: @rednek46
-echo *****************
-echo Removing Patch
-if exist "%APPDATA%\Spotify\dpapi.dll" (
-    del /s /q "%APPDATA%\Spotify\dpapi.dll" > NUL 2>&1
+echo ========================================
+echo  BlockTheSpot Uninstaller
+echo ========================================
+echo Authors: @rednek46, @Othmane-ElAlami
+echo ========================================
+echo.
+
+set /p UserInput="Do you want to continue with uninstallation? (y/n): "
+if /i "%UserInput%"=="y" (
+    echo.
+    echo Stopping Spotify processes...
+    taskkill /F /IM "Spotify.exe" /T >NUL 2>&1
+    timeout /t 2 /nobreak >NUL
+    
+    echo Removing BlockTheSpot files...
+    if exist "%APPDATA%\Spotify\dpapi.dll" (
+        del /q "%APPDATA%\Spotify\dpapi.dll" >NUL 2>&1
+        echo - Removed dpapi.dll
+    ) else (
+        echo - dpapi.dll not found
+    )
+    
+    if exist "%APPDATA%\Spotify\config.ini" (
+        del /q "%APPDATA%\Spotify\config.ini" >NUL 2>&1
+        echo - Removed config.ini
+    ) else (
+        echo - config.ini not found
+    )
+    
+    if exist "%APPDATA%\Spotify\blockthespot_settings.json" (
+        del /q "%APPDATA%\Spotify\blockthespot_settings.json" >NUL 2>&1
+        echo - Removed blockthespot_settings.json
+    ) else (
+        echo - blockthespot_settings.json not found
+    )
+    
+    echo.
+    echo BlockTheSpot uninstallation completed!
+    echo You can now use Spotify normally.
+    echo.
 ) else (
-    echo done
+    echo.
+    echo Uninstallation cancelled.
 )
 pause


### PR DESCRIPTION
This PR introduces a significant overhaul of the installation and uninstallation scripts. It adds a new PowerShell-based installer for a more modern experience, improves the robustness of the existing scripts, and makes the uninstallation process safer and more thorough.

**Key Changes:**

* **New PowerShell Installer for Spicetify**: Introduced a new PowerShell script to automate the installation of BlockTheSpot and Spicetify. This script includes verification, error handling, and status checks, providing a more reliable and user-friendly setup. The main batch script now delegates to this new installer.
* **Improved Error Handling in `install.ps1`**: The installation script has been refactored for greater robustness. It now includes improved error handling for file downloads, adds fallback mechanisms for BITS transfers, and provides clearer user feedback throughout the process.
* **Enhanced Uninstall Script**: The `uninstall.bat` script is now more interactive and safer. It prompts the user for confirmation before proceeding, automatically stops any running Spotify processes, and performs a more thorough cleanup of BlockTheSpot-related files.