### PR TITLE
Update invalid settings json link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ or
 1. Browse to your Spotify installation folder `%APPDATA%\Spotify`
 2. Download `chrome_elf.zip` from [releases](https://github.com/mrpond/BlockTheSpot/releases)
 3. Unzip `dpapi.dll` and `config.ini` to Spotify directory. 
-4. Download latest [blockthespot_settings.json](https://github.com/mrpond/BlockTheSpot/master/blockthespot_settings.json) from github to Spotify directory. 
+4. Download latest [blockthespot_settings.json](https://github.com/mrpond/BlockTheSpot/blob/master/blockthespot_settings.json) from github to Spotify directory. 
 ### Uninstall:
 * Just run [uninstall.bat](https://raw.githack.com/mrpond/BlockTheSpot/master/uninstall.bat)
 or


### PR DESCRIPTION
Fixes the invalid `blockthespot_settings.json` repository file link in the README.