### PR TITLE
Fix setting file removal close #625

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -264,7 +264,6 @@ Write-Host 'Patching Spotify...'
 $patchFiles = (Join-Path -Path $PWD -ChildPath 'dpapi.dll'), (Join-Path -Path $PWD -ChildPath 'config.ini')
 
 Copy-Item -LiteralPath $patchFiles -Destination "$spotifyDirectory"
-Remove-Item -LiteralPath (Join-Path -Path $spotifyDirectory -ChildPath 'blockthespot_settings.json') -Force -ErrorAction SilentlyContinue
 
 # function Install-VcRedist {
 #   $architecture = if ([Environment]::Is64BitOperatingSystem) { "x64" } else { "x86" }
@@ -273,7 +272,7 @@ Remove-Item -LiteralPath (Join-Path -Path $spotifyDirectory -ChildPath 'blockthe
 #   $registryPath = "HKLM:\Software\Microsoft\VisualStudio\14.0\VC\Runtimes\$architecture"
 #   $installedVersion = [version]((Get-ItemProperty $registryPath -ErrorAction SilentlyContinue).Version).Substring(1)
 #   $latestVersion = [version]"14.40.33810.0"
-# 
+#
 #   if ($installedVersion -lt $latestVersion) {
 #       $vcRedistFile = Join-Path -Path $PWD -ChildPath "vc_redist.$architecture.exe"
 #       Write-Host "Downloading and installing vc_redist.$architecture.exe..."
@@ -281,7 +280,7 @@ Remove-Item -LiteralPath (Join-Path -Path $spotifyDirectory -ChildPath 'blockthe
 #       Start-Process -FilePath $vcRedistFile -ArgumentList "/install /quiet /norestart" -Wait
 #   }
 # }
-# 
+#
 # Install-VcRedist
 
 $tempDirectory = $PWD


### PR DESCRIPTION
## Summary

This PR removes the BlockTheSpot settings file removal introduced in #542 as a non-related change to the #542 PR topic. 

The removal of the file is causing an infinite loop of updates, described [here](https://github.com/mrpond/BlockTheSpot/issues/625#issuecomment-3538901024).